### PR TITLE
ハンバーガーメニューの一覧にある項目（ユーザー情報）のパスが修正できていなかったため修正しました。

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,7 +20,7 @@
 </div>
 
 <div class="mobile-menu-content">
-  <%= link_to "ユーザー情報", user_my_page_path(current_user.id), class: "mobile-menu_link" %>
+  <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "mobile-menu_link" %>
   <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "mobile-menu_link" %>
   <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "mobile-menu_link" %>
 </div>


### PR DESCRIPTION
目的：
ハンバーガーメニューの一覧にある項目（ユーザー情報）のパスが修正できていなかったため修正しました。

内容：
・ハンバーガーメニューの中にあるユーザー情報のパスを「edit_user_custom_registration_path」に変更しました。
※これでハンバーガーメニュー展開時に表示される「ユーザー情報」をクリックすることでユーザー情報の編集画面に直接飛ぶことができます。