### PR TITLE
フラッシュメッセージを的確な場所に表示されるよう修正しました。

### DIFF
--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -10,13 +10,13 @@ class CustomRegistrationsController < ApplicationController
 
     #入力したデータでエラーがないかチェック
     if User.find_by(name: user.name)
-      flash[:notice] = "※そのユーザー名は既に使用されています。"
+      flash[:sign_up_notice] = "※そのユーザー名は既に使用されています。"
       render 'new'
     elsif User.find_by(email: user.email)
-      flash[:notice] = "※そのメールアドレスは既に使用されています。"
+      flash[:sign_up_notice] = "※そのメールアドレスは既に使用されています。"
       render 'new'
     elsif user.password != user.password_confirmation
-      flash[:notice] = "※入力したパスワードが一致しません。"
+      flash[:sign_up_notice] = "※入力したパスワードが一致しません。"
       render 'new'
     end
 
@@ -26,8 +26,6 @@ class CustomRegistrationsController < ApplicationController
       session[:user_id] = user.id
       # current_userに値を設定する
       sign_in(user)
-      #ログインしましたとアナウンス
-      flash[:notice] = "※ログインしました。"
       #もし一致する場合にはroot_pathへ移動（一時的にです。）
       redirect_to root_path
     end
@@ -44,18 +42,18 @@ class CustomRegistrationsController < ApplicationController
     if edit_user_params[:password].present? && edit_user_params[:password_confirmation].present?
       # パスワードがある場合の処理
       if !@user.valid_password?(edit_user_params[:current_password])
-        flash[:notice] = "現在のパスワードが正しくありません。"
+        flash[:edit_notice] = "現在のパスワードが正しくありません。"
         render :edit
         return
       end
 
       @user.update(edit_user_params)
-      flash[:notice] = "ユーザー情報とパスワードを更新しました。再度ログインをお願いします。"
+      flash[:sign_in_notice] = "ユーザー情報とパスワードを更新しました。再度ログインをお願いします。"
       redirect_to user_custom_session_path
     else
       # パスワードがない場合の処理
       @user.update(user_params_without_password)
-      flash[:notice] = "ユーザー情報を更新しました。（パスワード未更新：パスワードを設定された場合には入力漏れがないか確認してください。）"
+      flash[:edit_notice] = "ユーザー情報を更新しました。（パスワード未更新）"
       render :edit
     end
   end

--- a/app/controllers/custom_sessions_controller.rb
+++ b/app/controllers/custom_sessions_controller.rb
@@ -12,13 +12,11 @@ class CustomSessionsController < ApplicationController
       session[:user_id] = user.id
       # current_userに値を設定する
       sign_in(user)
-      #ログインしましたとアナウンス
-      flash[:notice] = "※ログインしました"
       #もし一致する場合にはroot_pathへ移動
       redirect_to root_path
     else
       #ログインできませんでしたとアナウンス
-      flash[:notice] = "※ユーザー名かパスワードのどちらかが違います。"
+      flash[:sign_in_notice] = "※ユーザー名かパスワードのどちらかが違います。"
       #合わない場合にはsessions#newへ戻る
       render 'new'
     end
@@ -32,7 +30,7 @@ class CustomSessionsController < ApplicationController
     #セッションの完全な処理
     reset_session
     #sessions#newへ戻る
-    flash[:notice] = "※ログアウトしました。"
+    flash[:sign_in_notice] = "※ログアウトしました。"
     #一時的にsigninの画面にパスを出しています。
     redirect_to new_user_custom_session_path
   end

--- a/app/views/custom_registrations/edit.html.erb
+++ b/app/views/custom_registrations/edit.html.erb
@@ -1,6 +1,10 @@
 <div class="edit-registration-container">
 
-  <%= render 'shared/flash_notice' %>
+  <% if flash[:edit_notice] %>
+    <div class="flash notice">
+      <%= flash[:edit_notice] %>
+    </div>
+  <% end %>
 
   <div class="registration-title">
     <h1>ユーザー情報更新</h1>

--- a/app/views/custom_registrations/new.html.erb
+++ b/app/views/custom_registrations/new.html.erb
@@ -1,6 +1,10 @@
 <div class="new-registration-container">
 
-  <%= render 'shared/flash_notice' %>
+  <% if flash[:sign_up_notice] %>
+    <div class="flash notice">
+      <%= flash[:sign_up_notice] %>
+    </div>
+  <% end %>
 
   <div class="registration-title">
     <h1>Sign up</h1>

--- a/app/views/custom_sessions/new.html.erb
+++ b/app/views/custom_sessions/new.html.erb
@@ -1,6 +1,10 @@
 <div class="new-session-container">
 
-  <%= render 'shared/flash_notice' %>
+  <% if flash[:sign_in_notice] %>
+    <div class="flash notice">
+      <%= flash[:sign_in_notice] %>
+    </div>
+  <% end %>
 
   <div class="session-title">
     <h1>Sign in</h1>

--- a/app/views/shared/_flash_notice.html.erb
+++ b/app/views/shared/_flash_notice.html.erb
@@ -1,5 +1,0 @@
-<% if flash[:notice] %>
-  <div class="flash notice">
-    <%= flash[:notice] %>
-  </div>
-<% end %>


### PR DESCRIPTION
目的
フラッシュメッセージの表示方法を改善し、ユーザーに対してより的確な情報提供を行えるようになりました。

内容
・フラッシュメッセージの表示をページごとに分けるため、コントローラーで使用するキーを指定しました。
・各ページのビューファイル内で適切なキーを指定し、関連するメッセージのみ表示されるようにしました。

これにより、他のビューファイルでのフラッシュメッセージの表示が制御され、不具合が改善されました。