### PR TITLE
RegistrationsControllerのupdateアクションにおいて不必要なインスタンス変数の削除とコードの簡潔化を行いました。

### DIFF
--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -32,27 +32,23 @@ class CustomRegistrationsController < ApplicationController
   end
 
   def edit
-    @user = current_user
   end
 
   def update
-    #ユーザーのデータを格納する
-    @user = current_user
-
     if edit_user_params[:password].present? && edit_user_params[:password_confirmation].present?
       # パスワードがある場合の処理
-      if !@user.valid_password?(edit_user_params[:current_password])
+      if !current_user.valid_password?(edit_user_params[:current_password])
         flash[:edit_notice] = "現在のパスワードが正しくありません。"
         render :edit
         return
       end
 
-      @user.update(edit_user_params)
+      current_user.update(edit_user_params)
       flash[:sign_in_notice] = "ユーザー情報とパスワードを更新しました。再度ログインをお願いします。"
       redirect_to user_custom_session_path
     else
       # パスワードがない場合の処理
-      @user.update(user_params_without_password)
+      current_user.update(user_params_without_password)
       flash[:edit_notice] = "ユーザー情報を更新しました。（パスワード未更新）"
       render :edit
     end

--- a/app/views/custom_registrations/edit.html.erb
+++ b/app/views/custom_registrations/edit.html.erb
@@ -15,7 +15,7 @@
   </div>
 
   <div class="registration-input">
-    <%= form_with model: @user, url: update_user_custom_registration_path, local: true, method: :patch do |f| %>
+    <%= form_with model: current_user, url: update_user_custom_registration_path, local: true, method: :patch do |f| %>
       <div class="registration-field">
         <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "ニックネーム" %>
       </div>


### PR DESCRIPTION
内容：
RegistrationsControllerのupdateアクションにおいて不必要なインスタンス変数の削除とコードの簡潔化を行いました。

目的：
update アクションにおけるインスタンス変数 @user の削除と、代わりに current_user を使用するように修正しました。これにより、不要なインスタンス変数の使用を減らし、コードをよりシンプルで理解しやすくしました。