### PR TITLE
ユーザー情報更新アクションのネストを浅くし、新規登録時のエラーチェックにおいてreturnステートメントを追加しました。

### DIFF
--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -12,21 +12,23 @@ class CustomRegistrationsController < ApplicationController
     if User.find_by(name: user.name)
       flash[:sign_up_notice] = "※そのユーザー名は既に使用されています。"
       render 'new'
+      return
     elsif User.find_by(email: user.email)
       flash[:sign_up_notice] = "※そのメールアドレスは既に使用されています。"
       render 'new'
+      return
     elsif user.password != user.password_confirmation
       flash[:sign_up_notice] = "※入力したパスワードが一致しません。"
       render 'new'
+      return
     end
 
     #問題なければログインする
-    if user.save
-      #セッションIDを払い出す
+    if flash[:sign_up_notice].present?
+      render 'new'
+    elsif user.save
       session[:user_id] = user.id
-      # current_userに値を設定する
       sign_in(user)
-      #もし一致する場合にはroot_pathへ移動（一時的にです。）
       redirect_to root_path
     end
   end
@@ -35,21 +37,21 @@ class CustomRegistrationsController < ApplicationController
   end
 
   def update
-    if edit_user_params[:password].present? && edit_user_params[:password_confirmation].present?
-      # パスワードがある場合の処理
-      if !current_user.valid_password?(edit_user_params[:current_password])
-        flash[:edit_notice] = "現在のパスワードが正しくありません。"
-        render :edit
-        return
-      end
+    # パスワードがない場合
+    unless edit_user_params[:password].present? && edit_user_params[:password_confirmation].present?
+      current_user.update(user_params_without_password)
+      flash[:edit_notice] = "ユーザー情報を更新しました。（パスワード未更新）"
+      render :edit
+      return
+    end
 
+    # パスワードが一致しない場合
+    if current_user.valid_password?(edit_user_params[:current_password])
       current_user.update(edit_user_params)
       flash[:sign_in_notice] = "ユーザー情報とパスワードを更新しました。再度ログインをお願いします。"
       redirect_to user_custom_session_path
     else
-      # パスワードがない場合の処理
-      current_user.update(user_params_without_password)
-      flash[:edit_notice] = "ユーザー情報を更新しました。（パスワード未更新）"
+      flash[:edit_notice] = "現在のパスワードが正しくありません。"
       render :edit
     end
   end


### PR DESCRIPTION
目的: 
ユーザー情報の更新アクションのネストを浅くし、可読性を向上させたいです。また、新規登録時のエラーチェックにおいてアクションの実行を終了するためにreturnステートメントを追加したいです。

内容:
・ユーザー情報の更新アクションのネストが深くなっていたため修正を行いました。
・新規登録時に入力したデータのエラーチェックの各ブロックにreturnステートメントを追加し、アクションの実行を終了するように修正しました。