### PR TITLE
topページに「献立リスト」「買い物メモ」へ飛ぶボタンを設定しました。

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -17,4 +17,6 @@
 body {
   background-image: url('background-image.jpg');
   background-size: cover;
+  margin: 0;
+  padding: 0;
 }

--- a/app/assets/stylesheets/user-index.scss
+++ b/app/assets/stylesheets/user-index.scss
@@ -1,0 +1,30 @@
+.button-set-container {
+  position: fixed;
+  bottom: 20px;
+  width: 100%;
+  text-align: center;
+
+  .menu-list-button{
+    @extend .home-page-button-style;
+  }
+
+  .shoppingList-button{
+    @extend .home-page-button-style;
+  }
+}
+
+
+.home-page-button-style {
+  margin-top: 10px;
+  padding: 10px 10%;
+  font-size: 15px;
+  background-color: #000000;
+  color: white;
+  border-radius: 20px;
+  // white-space: nowrap;
+
+  @media screen and (max-width: 400px) {
+    margin-top: 10px;
+    width: 90%;
+  }
+}

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,1 +1,10 @@
 <%= render 'shared/menu' %>
+
+<div class="button-set-container">
+  <%= button_to "献立リスト追加", root_path, method: :get, class: "menu-list-button" %>
+  <%= button_to "買い出しに行く", root_path, method: :get , class: "shoppingList-button"%>
+
+  <!-- 下記のリダイレクト先が完成次第、下記のコードに切り替えてください。（＃を取るのを忘れずに） -->
+  <%#= button_to "献立リストに追加", user_menus_path(current_user.id), class: "menu-list-button", method: :get %>
+  <%#= button_to "買い出しに行く", user_menus_path(current_user.id), class: "shoppingList-button", method: :get %>
+</div>


### PR DESCRIPTION
目的：
ユーザーがTOPページから献立リストと買い物メモに直接アクセスできるようにするため、これらのボタンを追加しました。

内容：
・"献立リスト"へのボタンをTOPページに追加しました。
・"買い物メモ"へのボタンもTOPページに追加しました。
※スタイルはレスポンシブにも対応しています。


<img width="1379" alt="スクリーンショット 2023-09-06 13 25 35" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/aee8cd0e-d554-4be4-8bdf-56909738cfe0">
<img width="340" alt="スクリーンショット 2023-09-06 13 25 49" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/5d7ea0a3-2f48-4ab2-9645-7b7d46925cbf">