### PR TITLE
TOPページに「献立リスト追加」へのリンクを追加し、新しいページを作成しました。

### DIFF
--- a/app/assets/stylesheets/menu_list.scss
+++ b/app/assets/stylesheets/menu_list.scss
@@ -1,0 +1,76 @@
+.menus_container{
+  text-align: center;
+  width: 100%;
+  @media screen and (max-width: 600px) {
+    text-align: center;
+  }
+
+  .original-menu-heading {
+    @extend .menu_heading;
+  }
+
+  .menu-list-heading {
+    @extend .menu_heading;
+  }
+
+  .menus_list {
+    .original-menu-button{
+      width: 50%;
+      height: 70px;
+      margin: 10px auto;
+      font-size: 20px;
+      background-color: #ffffff;
+      color: rgb(12, 12, 12);
+      border-radius: 20px;
+      border: 1px solid rgba(221, 195, 195, 0.2);
+      white-space: nowrap;
+      @media screen and (max-width: 600px) {
+        font-size: 15px;
+        width: 90%;
+        margin-top: 10px;
+        border-radius: 20px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+      }
+    }
+
+    .original_menus_list {
+      @extend .rounded-image;
+    }
+  }
+
+  .default_menus_list{
+    @extend .rounded-image;
+  }
+}
+
+// テンプレ化しているスタイル
+.menu_heading {
+  display: block;
+  margin-top: 80px;
+  font-size: 30px;
+  position: relative;
+  display: inline-block;
+  padding-bottom: 5px;
+  @media screen and (max-width: 460px) {
+    display: inline-block;
+    font-size: 20px;
+  }
+}
+
+.menu_heading::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background-color: #000000;
+}
+
+.rounded-image {
+  margin: 10px 5px;
+  border-radius: 11%;
+}

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,0 +1,10 @@
+class MenusController < ApplicationController
+
+  def index
+    menu_ids = UserMenu.where(user_id: current_user.id).pluck(:menu_id)
+    @original_menus = Menu.where(id: menu_ids)
+    @default_menus = Menu.where(original_menu: false)
+  end
+
+
+end

--- a/app/helpers/menus_helper.rb
+++ b/app/helpers/menus_helper.rb
@@ -1,0 +1,2 @@
+module MenusHelper
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,0 +1,2 @@
+class Menu < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   attr_accessor :current_password
+
+  has_many :menu_users
+  has_many :menus, through: :menu_users
 end

--- a/app/models/user_menu.rb
+++ b/app/models/user_menu.rb
@@ -1,0 +1,4 @@
+class UserMenu < ApplicationRecord
+  belongs_to :menu
+  belongs_to :user
+end

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,0 +1,26 @@
+<%= render 'shared/menu' %>
+
+<div class ="menus_container">
+
+  <h3 class="original-menu-heading">オリジナル献立</h3>
+
+  <div class ="menus_list">
+    <%= button_to "オリジナル献立作成", new_user_menu_path(current_user.id), class: "original-menu-button", method: :get %>
+
+    <div class="original_menus_list">
+      <% if @original_menus.any? %>
+        <% @original_menus.each do |menu| %>
+          <%= image_tag(rails_blob_path(menu.image.variant(resize_to_limit: [200, 200])), class: "rounded-image") %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <h3 class="menu-list-heading">標準献立</h3>
+
+  <div class ="default_menus_list">
+    <% @default_menus.each do |menu| %>
+      <%= image_tag(rails_blob_path(menu.image.variant(resize_to_limit: [200, 200])), class: "rounded-image") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,10 +1,10 @@
 <%= render 'shared/menu' %>
 
 <div class="button-set-container">
-  <%= button_to "献立リスト追加", root_path, method: :get, class: "menu-list-button" %>
+  <%= button_to "献立リスト追加", user_menus_path(current_user.id), class: "menu-list-button", method: :get %>
   <%= button_to "買い出しに行く", root_path, method: :get , class: "shoppingList-button"%>
 
   <!-- 下記のリダイレクト先が完成次第、下記のコードに切り替えてください。（＃を取るのを忘れずに） -->
-  <%#= button_to "献立リストに追加", user_menus_path(current_user.id), class: "menu-list-button", method: :get %>
+  <%#= button_to "献立リスト追加", user_menus_path(current_user.id), class: "menu-list-button", method: :get %>
   <%#= button_to "買い出しに行く", user_menus_path(current_user.id), class: "shoppingList-button", method: :get %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,11 @@ Rails.application.routes.draw do
     get 'users/sessions', to: 'custom_sessions#destroy', as: :destroy_user_custom_session
     get 'registrations/edit', to: 'custom_registrations#edit', as: :edit_user_custom_registration
     patch 'registrations/update', to: 'custom_registrations#update', as: :update_user_custom_registration
+
+
+    resources :users do
+      resources :menus do
+      end
+    end
   end
 end

--- a/db/migrate/20230906091255_create_menus.rb
+++ b/db/migrate/20230906091255_create_menus.rb
@@ -1,0 +1,13 @@
+class CreateMenus < ActiveRecord::Migration[7.0]
+  def change
+    create_table :menus do |t|
+      t.string :menu_name,               null: false, default: ""
+      t.text :menu_contents,             null: false, default: ""
+      t.string :contents,                null: false, default: ""
+      t.boolean :original_menu,          null: false, default: false
+      t.text :image_meta_data,           null: false, default: ""
+      t.string :image,                   null: false, default: ""
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230906234713_create_user_menus.rb
+++ b/db/migrate/20230906234713_create_user_menus.rb
@@ -1,0 +1,9 @@
+class CreateUserMenus < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_menus do |t|
+      t.references :user,                null: false
+      t.references :menu,                null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_28_094149) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_06_234713) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "menus", force: :cascade do |t|
+    t.string "menu_name", default: "", null: false
+    t.text "menu_contents", default: "", null: false
+    t.string "contents", default: "", null: false
+    t.boolean "original_menu", default: false, null: false
+    t.text "image_meta_data", default: "", null: false
+    t.string "image", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "user_menus", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "menu_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["menu_id"], name: "index_user_menus_on_menu_id"
+    t.index ["user_id"], name: "index_user_menus_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", default: "", null: false

--- a/test/controllers/menus_controller_test.rb
+++ b/test/controllers/menus_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MenusControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/menus.yml
+++ b/test/fixtures/menus.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/user_menus.yml
+++ b/test/fixtures/user_menus.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/menu_test.rb
+++ b/test/models/menu_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MenuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_menu_test.rb
+++ b/test/models/user_menu_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserMenuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
ユーザーが簡単に献立を選べるようにするためです。

内容：
・Menuモデル、UserMenuモデルを作成
・マイグレーションファイルを設定
・モデル同士のリレーション設定
・menusコントローラーを作成し、indexアクションを設定
・トップページに「献立リスト追加」へのリンクを追加
・必要なコントローラーを作成(app/app/controllers/menus_controller.rb)
・新しいページを作成（app/views/menus/index.html.erb）


<img width="1400" alt="スクリーンショット 2023-09-07 9 42 54" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/fac291ef-df3a-4819-bb1a-f628c87e2dfa">
<img width="300" alt="スクリーンショット 2023-09-07 9 43 19" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/15c39942-ab1e-40e4-84c6-b342f601ba5a">
