### PR TITLE
献立登録フォームの関連モデル（Ingredient）と関連ライブラリ（ Active Storage、image_processing）を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,5 @@ gem 'pry-byebug'
 gem 'action_args'
 # Sassコンパイラを導入するためのジェム
 gem 'sassc'
+#画像のリサイズに必要な「ImageMagick」を使用できるようにするジェム
+gem 'image_processing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -123,6 +126,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.1)
@@ -190,6 +194,8 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.5)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -242,6 +248,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  image_processing
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -10,4 +10,5 @@ class MenusController < ApplicationController
   def new
     @menu = Menu.new
   end
+
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,0 +1,3 @@
+class Ingredient < ApplicationRecord
+  belongs_to :menu
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,2 +1,6 @@
 class Menu < ApplicationRecord
+  has_many :menu_users
+  has_many :users, through: :menu_users
+  has_one_attached :image
+  has_many :ingredients
 end

--- a/db/migrate/20230908032753_create_ingredients.rb
+++ b/db/migrate/20230908032753_create_ingredients.rb
@@ -1,0 +1,11 @@
+class CreateIngredients < ActiveRecord::Migration[7.0]
+  def change
+    create_table :ingredients do |t|
+      t.references :menu,           null: false
+      t.string :name,               null: false, default: ""
+      t.integer :quantity,          null: false, default: ""
+      t.string :unit,               null: false, default: ""
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230908034052_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20230908034052_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,47 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_06_234713) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_08_034052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "ingredients", force: :cascade do |t|
+    t.bigint "menu_id", null: false
+    t.string "name", default: "", null: false
+    t.integer "quantity", null: false
+    t.string "unit", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["menu_id"], name: "index_ingredients_on_menu_id"
+  end
 
   create_table "menus", force: :cascade do |t|
     t.string "menu_name", default: "", null: false
@@ -47,4 +85,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_234713) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/test/fixtures/ingredients.yml
+++ b/test/fixtures/ingredients.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/ingredient_test.rb
+++ b/test/models/ingredient_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class IngredientTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
機能実装に基づき、関連モデルと関連ライブラリをfeature/menu-registration-viewブランチに共有するため

内容：
・Ingredientモデル作成
・migrateファイル設定
・MenuとIngredientのリレーション設定
・Active Storageの導入（Menuモデルにカラム追加、モデルとの関連付け設定）
・「gem 'image_processing’」を導入（画像のリサイズに必要）