### PR TITLE
フォームを動的に追加削除ができるよう設定

### DIFF
--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -7,7 +7,7 @@
 
   background-color: #ffffff;
   box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2);
-  padding: 20px;
+  padding: 15px;
   border-radius: 8px;
   margin: 0 auto;
   margin-top: 30px;
@@ -17,7 +17,6 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    padding: 20px 40px;
     box-sizing: border-box;
     width: 100%;
     margin: 20px auto 60px;
@@ -84,10 +83,13 @@
     .menu-registration-field input,
     textarea{
       width: 100%;
-      padding: 10px 4%;
+      padding-top: 13px;
+      padding-bottom: 13px;
+      padding-left: 8px;
+      margin-top: 7px;
       font-size: 13px;
-      margin-bottom: 13px;
-      margin-right: 13px;
+      margin-bottom: 7px;
+      margin-right: 7px;
       border-radius: 20px;
       border: 1px solid rgba(0, 0, 0, 0.2);
     }
@@ -155,6 +157,11 @@
             border-right: none;
           }
         }
+
+        .ingredient-name{
+          width: 450px;
+        }
+
         .ingredient-quantity{
           width: 60px;
         }
@@ -167,8 +174,35 @@
           padding: 10px;
           background-color: #f99d68;
           border: 1px solid #ccc;
+          @media screen and (max-width: 700px) {
+            display: none;
+          }
+        }
+
+        a {
+          text-decoration: none;
+          font-size: 15px;
+        }
+
+        .form-delete_button{
+          margin-left: 5px;
+          margin-right: 5px;
+          margin-top: 10px;
         }
       }
     }
+
+  .count-up-botton{
+    button{
+      width: 200px;
+      background-color: #f99d68;
+      border: #2c2c2c;
+      padding: 2%;
+      font-size: 15px;
+      color: #000000;
+      margin-top: 10px;
+      margin-bottom: 5px;
+    }
+  }
   }
 }

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,5 +1,4 @@
 class MenusController < ApplicationController
-  before_action :set_form_count, only: [:new, :new_confirm]
 
   def index
     menu_ids = UserMenu.where(user_id: current_user.id).pluck(:menu_id)
@@ -29,11 +28,6 @@ class MenusController < ApplicationController
 
 
   private
-
-  def set_form_count
-    @form_count = 0..9
-    @MaxCount = 14
-  end
 
   def menu_params
     params.require(:menu).permit(:menu_name, :menu_contents, :contents, :image, :image_meta_data, ingredients: [:form_number, :name, :quantity, :unit])

--- a/app/javascript/addForm.js
+++ b/app/javascript/addForm.js
@@ -1,0 +1,100 @@
+var formCount_view = 0;
+var formCount_back = -1;
+var maxFormCount_view = 15;
+
+document.addEventListener("turbo:load", function(event) {
+  // 一度数値をリセット
+  formCount_view = 0;
+  formCount_back = -1;
+
+  // コードを５つ構成
+  for (var i = 0; i < 5; i++) {
+    createNewForm();
+  }
+  updateMaxCountText()
+});
+
+document.addEventListener("turbo:load", function(event) {
+  var count_up_bottom = document.getElementById("form-count-up");
+  count_up_bottom.addEventListener("click", function(event) {
+    event.preventDefault();
+    createNewForm();
+    updateMaxCountText()
+  });
+});
+
+document.addEventListener("click", function (event) {
+  if (event.target.classList.contains("form-count-down")) {
+    event.preventDefault();
+    var container = event.target.closest(".custom-ingredient-fields");
+    container.remove();
+    updateFormNumbers();
+    formCount_view--;
+    formCount_back--;
+    updateMaxCountText()
+  }
+});
+
+
+function createNewForm() {
+  var formContainer = document.getElementById("ingredient-form-add-container");
+  var newFormCount_view = formCount_view + 1;
+  var paddedNewFormCount = newFormCount_view < 10 ? '0' + newFormCount_view : newFormCount_view;
+  paddedNewFormCount = paddedNewFormCount.toString().padStart(2, '0');
+
+  var newFormCount_back = formCount_back + 1;
+
+  if (formCount_view < maxFormCount_view) {
+    var newForm =
+      `<div class="custom-ingredient-fields">\
+        <div class ="form-delete_button">\
+          <a href="#" class="form-count-down" data-action="decrement",  id="form-count-down">❌</a>\
+        </div>\
+        <input value="${paddedNewFormCount}" autocomplete="off" type="hidden" name="menu[ingredients][[${newFormCount_back}]form_number]" id="menu_ingredients_[${newFormCount_back}]form_number">\
+        <span class="form-number">${paddedNewFormCount}</span>\
+        <input id="ingredient_name[${newFormCount_back}]" autofocus="autofocus" autocomplete="name" placeholder=" 食材名 (上限15文字)" maxlength="15" class="ingredient-name" value="" size="15" type="text" name="menu[ingredients][[${newFormCount_back}]name]">\
+        <input type="text" id="ingredient_quantity[${newFormCount_back}]" name="menu[ingredients][[${newFormCount_back}]quantity]" autofocus="true" autocomplete="quantity" placeholder=" 数量" maxlength="4" oninput="this.value = this.value.replace(/[^0-9.]/g, '')" class="ingredient-quantity">\
+        <select id="menu_ingredients_[${newFormCount_back}]unit" name="menu[ingredients][[${newFormCount_back}]unit]" class="ingredient-unit">\
+          <option value="" selected>単位</option>\
+          <option value="g">g</option>\
+          <option value="kg">kg</option>\
+          <option value="ml">ml</option>\
+          <option value="L">L</option>\
+          <option value="個">個</option>\
+          <option value="枚">枚</option>\
+          <option value="匹">匹</option>\
+          <option value="切れ">切れ</option>\
+          <option value="杯">杯</option>\
+          <option value="缶">缶</option>\
+          <option value="本">本</option>\
+          <option value="袋">袋</option>\
+          <option value="束">束</option>\
+          <option value="合">合</option>\
+          <option value="大さじ">大さじ</option>\
+          <option value="小さじ">小さじ</option>\
+        </select>\
+      </div>`;
+
+    formContainer.insertAdjacentHTML("beforeend", newForm);
+    formCount_view++;
+    formCount_back++;
+  }
+}
+
+function updateFormNumbers() {
+  var formContainers = document.querySelectorAll(".custom-ingredient-fields");
+  formContainers.forEach(function (container, index) {
+    // 各フォームの番号を更新
+    var formNumber = container.querySelector(".form-number");
+    if (formNumber) {
+      var paddedFormNumber = (index + 1 < 10) ? '0' + (index + 1) : (index + 1);
+      formNumber.textContent = paddedFormNumber;
+    }
+  });
+}
+
+function updateMaxCountText() {
+  var formCountLimit = document.getElementById("formCountLimit");
+  var countLimit = maxFormCount_view - formCount_view;
+  formCountLimit.textContent = "+作成あと(" + countLimit + "個)";
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,3 +5,4 @@ import jquery from "jquery"
 window.$ = jquery
 import "./nav_menu";
 import "./menu_validation";
+import "./addForm";

--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -52,8 +52,6 @@ document.addEventListener("turbo:load", function(event) {
         duplication_error.textContent = "⚠️重複登録された食材があります。";
       }
     }
-
-
   });
 });
 
@@ -66,7 +64,8 @@ function validateAndHighlightInput(element ,sub_errorMessage, inputElement, even
     sub_errorMessage.textContent = "⚠️必須";
     inputElement.style.backgroundColor = "rgb(255, 184, 184)";
   } else {
-    errorMessage.textContent = "";
+    menu_main_errorMessage.textContent = "";
+    sub_errorMessage.textContent = "";
     inputElement.style.backgroundColor = "";
   }
 }

--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -33,7 +33,6 @@
         <%= f.file_field :image, autofocus: true, autocomplete: "image", placeholder: "献立の写真" %>
       </div>
 
-
       <div class ="contents-title">
         <p>２.食材リスト設定</p>
       </div>
@@ -42,22 +41,15 @@
       <div id="ingredients-name-duplication-error" class="ingredients-error-message"></div>
 
       <div class="ingredient-registration-input">
-
         <div class="ingredient-registration-field">
-          <%= f.fields_for :ingredients do |ingredient_form| %>
-            <div class="ingredient-registration-field">
-              <% @form_count.each do |index| %>
-                <div class="custom-ingredient-fields">
-                  <%= ingredient_form.hidden_field :"[#{index}]form_number", value: index + 1 %>
-                  <span class="form-number"><%= format('%02d', index + 1) %></span>
-                  <%= ingredient_form.text_field :"[#{index}]name", id: "ingredient_name[#{index}]", autofocus: true, autocomplete: "name", placeholder: " 食材名 (上限15文字)", maxlength: 15, class: "ingredient-name", value: @menu.ingredients[index]&.name %>
-                  <%= ingredient_form.text_field :"[#{index}]quantity", id: "ingredient_quantity[#{index}]", autofocus: true, autocomplete: "quantity", placeholder: " 数量", maxlength: 4, class: "ingredient-quantity", value: @menu.ingredients[index]&.quantity, oninput: "this.value = this.value.replace(/[^0-9.]/g, '')" %>
-                  <%= ingredient_form.select :"[#{index}]unit", [['g', 'g'], ['kg', 'kg'], ['ml', 'ml'], ['L', 'L'], ['個', '個'], ['枚', '枚'], ['匹', '匹'], ['切れ', '切れ'], ['丁', '丁'], ['杯', '杯'], ['缶', '缶'], ['本', '本'], ['袋', '袋'], ['束', '束'], ['合', '合'], ['大さじ', '大さじ'], ['小さじ', '小さじ']], prompt: '単位', class: "ingredient-unit", selected:  @menu.ingredients[index]&.unit, id: "ingredient_unit[#{index}]" %>
-                </div>
-              <% end %>
-            </div>
-          <% end %>
+          <div id="ingredient-form-add-container">
+            <%= f.fields_for :ingredients do |ingredient_form| %>
+            <% end %>
+          </div>
+        </div>
 
+        <div class="count-up-botton">
+          <button class="form-count-up" data-action="increment" id="form-count-up"><span id="formCountLimit"></span></button>
         </div>
       </div>
 


### PR DESCRIPTION
目的：
ユーザーがフォームを簡単に追加および削除できるようにすることで、使いやすさを向上させ、データ入力プロセスを効率化します。

内容：
・フォームの追加: ユーザーが「＋作成」ボタンをクリックすることで、新しいフォームが動的に追加されるようになりました。最大で15個のフォームまで追加できます。
・フォームの削除: 各フォームには「❌」アイコンがあり、ユーザーがクリックすることでフォームを削除できます。フォームを削除すると、残りのフォームの番号が自動的に更新されます。
・フォーム表示時には初期フォームとして５個フォームを設定しています。

<img width="1023" alt="スクリーンショット 2023-10-10 8 48 46" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/2d5fa178-6336-4578-9237-ddb372515630">
<img width="631" alt="スクリーンショット 2023-10-10 8 49 08" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/0577fcb9-79b5-46e7-9fdc-634fe4fbd6ab">
