### PR TITLE
Ingredientモデルから不要なform_numberカラムを削除しました。

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -9,7 +9,7 @@ class MenusController < ApplicationController
 
   def new
     @menu = Menu.new
-    new_ingredients(@menu)
+    @menu.ingredients = Ingredient.new
   end
 
 
@@ -30,14 +30,14 @@ class MenusController < ApplicationController
   private
 
   def menu_params
-    params.require(:menu).permit(:menu_name, :menu_contents, :contents, :image, :image_meta_data, ingredients: [:form_number, :name, :quantity, :unit])
+    params.require(:menu).permit(:menu_name, :menu_contents, :contents, :image, :image_meta_data, ingredients: [:name, :quantity, :unit])
   end
 
   def new_ingredient_forms(menu)
     ingredient_forms_data = @menu.ingredients
 
     ingredient_forms = []
-    ingredient_forms_data.each do |form_number, form_data|
+    ingredient_forms_data.each do |name, form_data|
       ingredient_form = Ingredient.new(form_data)
       ingredient_forms << ingredient_form
     end
@@ -49,13 +49,6 @@ class MenusController < ApplicationController
     end
 
     @menu.ingredients = ingredient_forms
-  end
-
-
-  def new_ingredients(menu)
-    menu.ingredients = []
-    setting_form_number = 10
-    setting_form_number.times { menu.ingredients << Ingredient.new }
   end
 
   def validate_unique_name(ingredients)

--- a/app/javascript/addForm.js
+++ b/app/javascript/addForm.js
@@ -50,7 +50,6 @@ function createNewForm() {
         <div class ="form-delete_button">\
           <a href="#" class="form-count-down" data-action="decrement",  id="form-count-down">❌</a>\
         </div>\
-        <input value="${paddedNewFormCount}" autocomplete="off" type="hidden" name="menu[ingredients][[${newFormCount_back}]form_number]" id="menu_ingredients_[${newFormCount_back}]form_number">\
         <span class="form-number">${paddedNewFormCount}</span>\
         <input id="ingredient_name[${newFormCount_back}]" autofocus="autofocus" autocomplete="name" placeholder=" 食材名 (上限15文字)" maxlength="15" class="ingredient-name" value="" size="15" type="text" name="menu[ingredients][[${newFormCount_back}]name]">\
         <input type="text" id="ingredient_quantity[${newFormCount_back}]" name="menu[ingredients][[${newFormCount_back}]quantity]" autofocus="true" autocomplete="quantity" placeholder=" 数量" maxlength="4" oninput="this.value = this.value.replace(/[^0-9.]/g, '')" class="ingredient-quantity">\

--- a/db/migrate/20230908032753_create_ingredients.rb
+++ b/db/migrate/20230908032753_create_ingredients.rb
@@ -1,8 +1,6 @@
 class CreateIngredients < ActiveRecord::Migration[7.0]
   def change
     create_table :ingredients do |t|
-      t.references :menu,           null: false
-      t.integer :form_number,       null: false, default: ""
       t.string :name,               null: false, default: ""
       t.integer :quantity,          null: false, default: ""
       t.string :unit,               null: false, default: ""

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,14 +43,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_073545) do
   end
 
   create_table "ingredients", force: :cascade do |t|
-    t.bigint "menu_id", null: false
-    t.integer "form_number", null: false
     t.string "name", default: "", null: false
     t.integer "quantity", null: false
     t.string "unit", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["menu_id"], name: "index_ingredients_on_menu_id"
   end
 
   create_table "menu_ingredients", force: :cascade do |t|


### PR DESCRIPTION
目的：
Ingredientモデルから不必要なform_numberカラムを削除し、関連するJavaScriptファイルおよびコントローラーを修正することです。

内容：
・Ingredientモデルから不必要なform_numberカラムを削除
・app/controllers/ingredients_controller.rbファイルには、不要なform_numberに関連する処理が削除しました。
・JavaScriptファイルが修正され、form_numberに関連するコードを削除しました。