### PR TITLE
食材フォームを自由入力から選択式に変更するためにUnitモデルを作成しました。

### DIFF
--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,0 +1,2 @@
+class Unit < ApplicationRecord
+end

--- a/db/migrate/20231013173246_create_units.rb
+++ b/db/migrate/20231013173246_create_units.rb
@@ -1,0 +1,8 @@
+class CreateUnits < ActiveRecord::Migration[7.0]
+  def change
+    create_table :units do |t|
+      t.string :unit_name,               null: false, default: ""
+      t.timestamps                       default: -> { 'CURRENT_TIMESTAMP' }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_29_073545) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_13_173246) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,6 +68,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_073545) do
     t.string "image", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "units", force: :cascade do |t|
+    t.string "unit_name", default: "", null: false
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
   end
 
   create_table "user_menus", force: :cascade do |t|

--- a/test/fixtures/units.yml
+++ b/test/fixtures/units.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/unit_test.rb
+++ b/test/models/unit_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UnitTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
Menuフォームにある食材フォームを自由入力から選択式に変更するために必要になるため作成しました。

内容：
・食材登録時に食材ごとに適切な単位を設定できるようにするためにUnitモデルを作成
・カラムとしてunit_nameを設定