### PR TITLE
食材データベースを作成するためにmaterialモデルを作成しました。

### DIFF
--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,0 +1,2 @@
+class Material < ApplicationRecord
+end

--- a/db/migrate/20231017081956_create_materials.rb
+++ b/db/migrate/20231017081956_create_materials.rb
@@ -7,5 +7,7 @@ class CreateMaterials < ActiveRecord::Migration[7.0]
       t.references :unit,                    null: false
       t.timestamps default: -> { 'CURRENT_TIMESTAMP' }
     end
+    # ここでのunitは変換時に利用するデータです。
+    # 通常時の単位は中間モデルで設定しています。
   end
 end

--- a/db/migrate/20231017081956_create_materials.rb
+++ b/db/migrate/20231017081956_create_materials.rb
@@ -1,0 +1,11 @@
+class CreateMaterials < ActiveRecord::Migration[7.0]
+  def change
+    create_table :materials do |t|
+      t.string :material_name,               null: false, default: ""
+      t.integer :conversion_factor,          null: false, default: ""
+      t.references :category,                null: false
+      t.references :unit,                    null: false
+      t.timestamps default: -> { 'CURRENT_TIMESTAMP' }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_14_075814) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_17_081956) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,6 +54,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_14_075814) do
     t.string "unit", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "materials", force: :cascade do |t|
+    t.string "material_name", default: "", null: false
+    t.integer "conversion_factor", null: false
+    t.bigint "category_id", null: false
+    t.bigint "unit_id", null: false
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["category_id"], name: "index_materials_on_category_id"
+    t.index ["unit_id"], name: "index_materials_on_unit_id"
   end
 
   create_table "menu_ingredients", force: :cascade do |t|

--- a/test/fixtures/materials.yml
+++ b/test/fixtures/materials.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/material_test.rb
+++ b/test/models/material_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MaterialTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
食材データベースを構築するための新しいmaterialモデルを導入することです。

内容：
・下記のカラムを設定
　material_name: 食材の名前を格納します。
　category_id: 食材のカテゴリを指定する外部キーです。
　conversion_factor: 食材の数量を変換するための係数です。
　unit_id: 食材の数量の単位を指定する外部キーです。
　※これは複数のmaterialを合算する際に採用される単位です。