### PR TITLE
“name、unitカラムを外部キーとして参照先のmaterial_unitsとunitsに変更”

### DIFF
--- a/db/migrate/20230908032753_create_ingredients.rb
+++ b/db/migrate/20230908032753_create_ingredients.rb
@@ -1,9 +1,9 @@
 class CreateIngredients < ActiveRecord::Migration[7.0]
   def change
     create_table :ingredients do |t|
-      t.string :name,               null: false, default: ""
-      t.integer :quantity,          null: false, default: ""
-      t.string :unit,               null: false, default: ""
+      t.references :material_unit,  null: false
+      t.references :unit,           null: false
+      t.integer :quantity
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,11 +49,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_110904) do
   end
 
   create_table "ingredients", force: :cascade do |t|
-    t.string "name", default: "", null: false
-    t.integer "quantity", null: false
-    t.string "unit", default: "", null: false
+    t.bigint "material_unit_id", null: false
+    t.bigint "unit_id", null: false
+    t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["material_unit_id"], name: "index_ingredients_on_material_unit_id"
+    t.index ["unit_id"], name: "index_ingredients_on_unit_id"
   end
 
   create_table "material_units", force: :cascade do |t|


### PR DESCRIPTION
目的：
食材登録のフォームを自由入力から選択方式に変更するためです。

内容：
・name、unitカラムを外部キーとして参照先のmaterial_unitsとunitsに変更
※quantityについては値を入力しない場合があるため、「null: false, default: ""」を削除しました。