### PR TITLE
食材ドロップダウンと検索結果の表示順を修正

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -10,7 +10,7 @@ class MenusController < ApplicationController
   def new
     @menu = Menu.new
     @menu.ingredients = Ingredient.new
-    @materials_by_category = MaterialUnit.includes(:material).group_by { |mu| mu.material.category }
+    @materials_by_category = fetch_materials_grouped_by_category
   end
 
 
@@ -59,6 +59,13 @@ class MenusController < ApplicationController
       return false
     end
     return true
+  end
+
+  def fetch_materials_grouped_by_category
+    all_materials = Material.includes(:category).order(:hiragana)
+    materials_grouped_by_category = all_materials.group_by(&:category)
+    sorted_by_category = materials_grouped_by_category.sort_by { |category, _| category.id }.to_h
+    sorted_materials_within_categories = sorted_by_category.transform_values { |materials| materials.sort_by(&:hiragana) }
   end
 
 end

--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -57,10 +57,10 @@
                       <p id="categoryElement-<%= index %>" class="categoryElement"><%= category.category_name %></p>
 
                       <ul id="ingredients-list-<%= index %>" style="display: none;">
-                        <% materials.each do |material_unit| %>
-                          <% if material_unit.material && material_unit.unit %>
-                            <li data-value="<%= material_unit.material.material_name %>">
-                              <%= material_unit.material.material_name %>
+                        <% materials.each do |material| %>
+                          <% if material.material_name %>
+                            <li data-value="<%= material.material_name %>" data-hiragana="<%= material.hiragana %>">
+                              <%= material.material_name %>
                           <% end %>
                         <% end %>
                       </ul>

--- a/db/migrate/20231017081956_create_materials.rb
+++ b/db/migrate/20231017081956_create_materials.rb
@@ -6,6 +6,7 @@ class CreateMaterials < ActiveRecord::Migration[7.0]
       t.references :category,                null: false
       t.references :unit,                    null: false
       t.string :default_name,                null: false, default: ""
+      t.string :hiragana,                    null: false, default: ""
       t.timestamps default: -> { 'CURRENT_TIMESTAMP' }
     end
     # ここでのunitは変換時に利用するデータです。

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_110904) do
     t.bigint "category_id", null: false
     t.bigint "unit_id", null: false
     t.string "default_name", default: "", null: false
+    t.string "hiragana", default: "", null: false
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["category_id"], name: "index_materials_on_category_id"


### PR DESCRIPTION
目的：
ユーザーが食材を選択や検索する際の使い勝手を向上させるためです。

内容：
・食材を50音順に表示するためにMaterialモデルに「hiraganaカラム」を追加
・ドロップダウンリスト及び、検索結果が食材を50音順に表示するように変更しました。
・検索アルゴリズムを改善し、マッチングの精度を向上させました。
※具体的には「ひらがな」と「漢字」それぞれに前方一致と部分一致のアルゴリズムを設定しました。
