### PR TITLE
食材登録フォームで手動入力ができてしまう不具合を修正

### DIFF
--- a/app/javascript/addForm.js
+++ b/app/javascript/addForm.js
@@ -51,7 +51,7 @@ function createNewForm() {
           <a href="#" class="form-count-down" data-action="decrement",  id="form-count-down[${newFormCount_back}]">❌</a>
         </div>
         <span class="form-number">${paddedNewFormCount}</span>
-        <input id="ingredient_name[${newFormCount_back}]" class="ingredient-name" placeholder="食材名を選択" type="text" name="menu[ingredients][${newFormCount_back}][name]">
+        <input id="ingredient_name[${newFormCount_back}]" class="ingredient-name" placeholder="食材名を選択" type="text" name="menu[ingredients][${newFormCount_back}][name]" readonly>
         <input type="text" id="ingredient_quantity[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][quantity]" autocomplete="quantity" placeholder="数量" maxlength="4" oninput="this.value = this.value.replace(/[^0-9.]/g, '')" class="ingredient-quantity">
       </div>`;
 


### PR DESCRIPTION
目的：
食材登録フォームでの不正なデータの登録を防ぐためです。

内容：
・食材登録フォームの入力フィールドにreadonly属性を追加しました。
※この変更により、ユーザーはドロップダウンリストからの選択のみが可能となり、手動での入力はできなくなります。