### PR TITLE
SCSSの改行を1行に統一し、スタイルをケバブケースに統一

### DIFF
--- a/app/assets/stylesheets/menu-bar.scss
+++ b/app/assets/stylesheets/menu-bar.scss
@@ -6,12 +6,12 @@
 
 
   // ロゴのスタイル
-  .menu-bar_left {
+  .menu-bar-left {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
 
-    .menu-bar_app-name {
+    .menu-bar-app-name {
       color: rgb(0, 0, 0);
       font-size: 30px;
       font-weight: bold;
@@ -24,7 +24,7 @@
       }
     }
 
-    .menu-bar_subtitle {
+    .menu-bar-subtitle {
       color: #0e0d0d;
       font-weight: bold;
       font-size: 12px;
@@ -39,10 +39,10 @@
 
 
 // メニューのスタイル
-.menu-bar_right {
+.menu-bar-right {
   .desktop-menu{
   // CP画面のスタイル
-    .menu_link {
+    .menu-link {
       font-weight: bold;
       color: #000000;
       font-size: 17px;
@@ -54,7 +54,7 @@
 
     // リンクテキストのスタイル
     @media screen and (max-width: 900px){
-      .menu_link {
+      .menu-link {
         display: none;
       }
     }
@@ -112,7 +112,7 @@
   flex-direction: column;
   align-items: center;
   opacity: 0;
-  .mobile-menu_link{
+  .mobile-menu-link{
     display: block;
     font-weight: bold;
     color: #ffff;

--- a/app/assets/stylesheets/menu/menu_list.scss
+++ b/app/assets/stylesheets/menu/menu_list.scss
@@ -1,4 +1,4 @@
-.menus_container{
+.menus-container{
   text-align: center;
   width: 100%;
   @media screen and (max-width: 600px) {
@@ -6,11 +6,11 @@
   }
 
   .original-menu-heading {
-    @extend .menu_heading;
+    @extend .menu-heading;
   }
 
   .menu-list-heading {
-    @extend .menu_heading;
+    @extend .menu-heading;
   }
 
   .menus_list {
@@ -41,13 +41,13 @@
     }
   }
 
-  .default_menus_list{
+  .default-menus-list{
     @extend .rounded-image;
   }
 }
 
 // テンプレ化しているスタイル
-.menu_heading {
+.menu-heading {
   display: block;
   margin-top: 80px;
   font-size: 30px;
@@ -60,7 +60,7 @@
   }
 }
 
-.menu_heading::after {
+.menu-heading::after {
   content: "";
   position: absolute;
   left: 0;

--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -123,8 +123,6 @@
     }
   }
 
-  // 献立リストのスタイル
-
   // 献立画面のスタイル
   .ingredient-registration-input{
     width: 100%;
@@ -171,7 +169,7 @@
           padding-right: 10px;
         }
 
-        .form-delete_button{
+        .form-delete-button{
           margin-top: 10px;
         }
 
@@ -185,7 +183,7 @@
         }
       }
 
-      .ingredient_select{
+      .ingredient-select{
         display: none;
         position: absolute;
         left: 34%;
@@ -224,14 +222,13 @@
           border: 1px solid rgba(0, 0, 0, 0.2);
         }
 
-
         .scrollable-section{
           max-height: 500px;
           overflow-y: auto;
         }
 
-        .search_results_title,
-        .drop_down_title{
+        .search-results-title,
+        .drop-down-title{
           text-align:  center;
           font-size: 25px;
         }
@@ -253,29 +250,32 @@
           background-color: rgba(0, 0, 0, 0.1);
         }
 
-        .ingredient-category ul {
-          list-style-type: none;
-          font-size: 20px;
+        .ingredient-category {
+          ul {
+            list-style-type: none;
+            font-size: 20px;
+            li {
+              text-align: left;
+              cursor: pointer;
+
+              &:hover {
+                background-color: rgba(0, 0, 0, 0.1);
+              }
+            }
+          }
+
+          .categoryElement {
+            font-size: 20px;
+            padding-left: 50px;
+            text-align: left;
+            cursor: pointer;
+            &:hover {
+              background-color: rgba(0, 0, 0, 0.1);
+            }
+          }
         }
 
-        .ingredient-category .categoryElement {
-          font-size: 20px;
-          padding-left: 50px;
-          text-align: left;
-          cursor: pointer;
-        }
-
-        .ingredient-category .categoryElement:hover,
-        .ingredient-category ul li:hover {
-          background-color: rgba(0, 0, 0, 0.1);
-        }
-
-        .ingredient-category ul li {
-          text-align: left;
-          cursor: pointer;
-        }
-
-        .search_results_title {
+        .search-results-title {
           display: none;
         }
       }
@@ -296,7 +296,6 @@
   }
   }
 }
-
 
 .dropdown-bg {
   display: none;

--- a/app/javascript/addForm.js
+++ b/app/javascript/addForm.js
@@ -47,7 +47,7 @@ function createNewForm() {
   if (formCount_view < maxFormCount_view) {
     var newForm = `
       <div class="custom-ingredient-fields">
-        <div class="form-delete_button">
+        <div class="form-delete-button">
           <a href="#" class="form-count-down" data-action="decrement",  id="form-count-down[${newFormCount_back}]">❌</a>
         </div>
         <span class="form-number">${paddedNewFormCount}</span>

--- a/app/javascript/ingredient_dropdown.js
+++ b/app/javascript/ingredient_dropdown.js
@@ -1,8 +1,8 @@
-let searchResultsTitle = document.querySelector(".search_results_title");
+let searchResultsTitle = document.querySelector(".search-results-title");
 let dropdownBg = document.getElementById('dropdownBackground');
 let closeButton = document.querySelector('.close-button');
 const searchResultsContainer = document.getElementById('searchResultsContainer');
-const ingredientList = document.getElementById(`ingredient_select`);
+const ingredientList = document.getElementById(`ingredient-select`);
 
 document.addEventListener("turbo:load", function() {
   let ingredientName = null;

--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -45,12 +45,12 @@
           <div id="ingredient-form-add-container">
             <%= f.fields_for :ingredients do |ingredient_form| %>
               <div id="ingredient_form"></div>
-              <div id="ingredient_select" class="ingredient_select">
+              <div id="ingredient_select" class="ingredient-select">
                 <span class="close-button">×</span>
                 <input type="text" id="ingredientSearchInput" class="SearchInput" placeholder="食材名を入力+Enter" />
-                <p class="search_results_title">検索結果</p>
+                <p class="search-results-title">検索結果</p>
                 <div id="searchResultsContainer" class="searchContainer"></div>
-                <p class="drop_down_title">食材一覧</p>
+                <p class="drop-down-title">食材一覧</p>
                 <div class="scrollable-section">
                   <% @materials_by_category.each_with_index do |(category, materials), index| %>
                     <div class="ingredient-category">

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/menu' %>
 
-<div class ="menus_container">
+<div class ="menus-container">
 
   <h3 class="original-menu-heading">オリジナル献立</h3>
 
@@ -18,7 +18,7 @@
 
   <h3 class="menu-list-heading">標準献立</h3>
 
-  <div class ="default_menus_list">
+  <div class ="default-menus-list">
     <% @default_menus.each do |menu| %>
       <%= image_tag(rails_blob_path(menu.image.variant(resize_to_limit: [200, 200])), class: "rounded-image") %>
     <% end %>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -1,13 +1,13 @@
 <div class="menu-bar">
-  <div class="menu-bar_left">
-    <span class="menu-bar_app-name">Autonomy</span>
-    <span class="menu-bar_subtitle">~自炊で毎日の健康管理を~</span>
+  <div class="menu-bar-left">
+    <span class="menu-bar-app-name">Autonomy</span>
+    <span class="menu-bar-subtitle">~自炊で毎日の健康管理を~</span>
   </div>
-  <div class="menu-bar_right">
+  <div class="menu-bar-right">
     <div id="menu" class="desktop-menu">
-      <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "menu_link" %>
-      <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "menu_link" %>
-      <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "menu_link" %>
+      <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "menu-link" %>
+      <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "menu-link" %>
+      <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "menu-link" %>
     </div>
     <div class="mobile-menu-botton">
       <button class="hamburger">
@@ -20,9 +20,9 @@
 </div>
 
 <div class="mobile-menu-content">
-  <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "mobile-menu_link" %>
-  <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "mobile-menu_link" %>
-  <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "mobile-menu_link" %>
+  <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "mobile-menu-link" %>
+  <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "mobile-menu-link" %>
+  <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "mobile-menu-link" %>
 </div>
 
 <div id="mask"></div>


### PR DESCRIPTION
目的:
SCSSのコードの可読性と整合性を向上させるため。

内容:
・SCSS内の改行を1行に統一しました。これにより、コードの見た目が統一され、可読性が向上します。
・既存のキャラメルケースやスネークケースで書かれていたスタイルをケバブケースに統一しました。これにより、SCSSのスタイルの命名規則が一貫性を持つようになります。