### PR TITLE
食材セット時にunitフォームへ専用の単位を設定されるようにしました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,15 +71,10 @@ group :test do
   gem "webdrivers"
 end
 
-# ユーザー認証機能を実装するためのDevise Gemを導入します。
 gem 'devise'
-# デバッグ用のコンソールツールを導入するためのジェム
 gem 'pry-rails'
-# Pryとbyebugを組み合わせたデバッグ用のジェム
 gem 'pry-byebug'
-# コントローラーのアクションに引数を渡すためのジェム
 gem 'action_args'
-# Sassコンパイラを導入するためのジェム
 gem 'sassc'
-#画像のリサイズに必要な「ImageMagick」を使用できるようにするジェム
 gem 'image_processing'
+gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.7)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.5.1)
@@ -255,6 +257,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.5)
   sassc
   selenium-webdriver

--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -12,7 +12,7 @@
   margin: 0 auto;
   margin-top: 30px;
   margin-bottom: 30px;
-  @media screen and (max-width: 600px) {
+  @media screen and (max-width: 800px) {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -140,13 +140,12 @@
         margin-top: 2px;
 
         .ingredient-name,
-        .ingredient-quantity{
+        .ingredient-quantity,
+        .ingredient-unit{
           display: block;
           border: none;
           padding: 10px;
-          border-right: 1px solid #ccc;
-          border-bottom: 1px solid #ccc;
-          border-top: 1px solid #ccc;
+          border: 1px solid #ccc;
           @media screen and (max-width: 400px) {
             width: 90%;
             border-bottom: 1px solid #ccc;
@@ -160,6 +159,10 @@
 
         .ingredient-quantity{
           width: 60px;
+        }
+
+        .ingredient-unit{
+          width: 162px;
         }
 
         a {

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -10,7 +10,7 @@ class MenusController < ApplicationController
   def new
     @menu = Menu.new
     @menu.ingredients = Ingredient.new
-    @materials_by_category = Material.includes(:category).order('categories.id, hiragana').group_by { |m| m.category.category_name }
+    @materials_by_category = fetch_sorted_materials_by_category
   end
 
 
@@ -28,6 +28,14 @@ class MenusController < ApplicationController
     #   flash[:error] = "誤った入力が検出されました。"
     #   redirect_to new_user_menu_path
     # end
+  end
+
+  def units
+    material = Material.find_by(material_name: params[:material_name])
+    units = material.material_units.map do |material_unit|
+      { id: material_unit.unit_id, name: material_unit.unit.unit_name }
+    end
+    render json: units
   end
 
   private
@@ -59,6 +67,17 @@ class MenusController < ApplicationController
       return false
     end
     return true
+  end
+
+  def fetch_sorted_materials_by_category
+    materials_by_category = {}
+    sorted_materials = Material.includes(:category).order('categories.id', :hiragana)
+    grouped_materials = sorted_materials.group_by { |m| m.category.category_name }
+
+    grouped_materials.each do |category_name, materials|
+      materials_by_category[category_name] = materials.sort_by(&:hiragana)
+    end
+    materials_by_category
   end
 
 end

--- a/app/javascript/addForm.js
+++ b/app/javascript/addForm.js
@@ -53,6 +53,9 @@ function createNewForm() {
         <span class="form-number">${paddedNewFormCount}</span>
         <input id="ingredient_name[${newFormCount_back}]" class="ingredient-name" placeholder="食材名を選択" type="text" name="menu[ingredients][${newFormCount_back}][name]" readonly>
         <input type="text" id="ingredient_quantity[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][quantity]" autocomplete="quantity" placeholder="数量" maxlength="4" oninput="this.value = this.value.replace(/[^0-9.]/g, '')" class="ingredient-quantity">
+        <select id="menu_ingredients_unit[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][unit]" class="ingredient-unit">
+          <option value="">食材を選択</option>
+        </select>
       </div>`;
 
     ingredient_form.insertAdjacentHTML("beforeend", newForm);

--- a/app/javascript/ingredient_dropdown.js
+++ b/app/javascript/ingredient_dropdown.js
@@ -37,6 +37,7 @@ document.addEventListener("turbo:load", function() {
     }
 
     e.preventDefault();
+    matchedItems = [];
     searchResultsContainer.innerHTML = '';
     const searchText = searchInput.value.trim();
 
@@ -97,7 +98,11 @@ document.addEventListener("turbo:load", function() {
 
     matchedItems = [];
     ingredientName.value = e.target.textContent.trim();
+    let parentElement = ingredientName.parentElement;
+    let selectElement = parentElement.querySelector(".ingredient-unit");
     closeDropdown()
+
+    handleIngredientNameChange(selectElement, ingredientName.value);
   });
 
   // 検索した食材を選んだらフォームに値をセットする
@@ -106,7 +111,11 @@ document.addEventListener("turbo:load", function() {
 
     matchedItems = [];
     ingredientName.value = e.target.textContent.trim();
+    let parentElement = ingredientName.parentElement;
+    let selectElement = parentElement.querySelector(".ingredient-unit");
     closeDropdown()
+
+    handleIngredientNameChange(selectElement, ingredientName.value);
   });
 
   // 食材リストを表示/非表示に切り替える
@@ -197,4 +206,37 @@ function closeDropdown() {
   dropdownBg.style.display = "none";
   ingredientList.style.display = "none";
   clearSearchResults();
+}
+
+// 食材セット時にunitフォームへ専用の単位を設定する
+function handleIngredientNameChange(selectElement, value) {
+  const material_name = value;
+  const userId = document.querySelector('.menu-registration-container').getAttribute('data-user-id');
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const url = `/users/${userId}/menus/units`;
+  console.log(userId);
+  fetch(url, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': token
+    },
+    body: JSON.stringify({ material_name: material_name })
+  })
+  .then(response => response.json())
+  .then(data => {
+
+    while (selectElement.firstChild) {
+      selectElement.removeChild(selectElement.firstChild);
+    }
+
+    data.forEach(item => {
+      const option = document.createElement('option');
+      option.value = item.id;
+      option.textContent = item.name;
+      selectElement.appendChild(option);
+    });
+  });
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>AutonomyApp</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="csrf-token" content="<%= form_authenticity_token %>">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= javascript_importmap_tags %>

--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="menu-registration-container">
+<div class="menu-registration-container" data-user-id="<%= current_user.id %>">
 
   <div class="menu-registration-title">
     <h1>献立登録</h1>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,13 @@ module AutonomyApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        # resource '/users/:user_id/menus/units', headers: :any, methods: [:post]
+        resource '/autocomplete_ingredients', headers: :any, methods: [:post]
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
 
 
     post '/users/:user_id/menus/new_confirm', to: 'menus#new_confirm', as: :new_confirm_user_menu
+    post 'users/:user_id/menus/units', to: 'menus#units'
+
 
     resources :users do
       resources :menus do


### PR DESCRIPTION
目的：
食材選択時に専用の単位を設定する機能の実装

内容：
・単位選択ができるフォームを追加
・JavaScriptにてサーバーサイドにアクセスできるよう「gem 'rack-cors'」を導入
・JavaScriptにてサーバーサイドにアクセスする際に単位を検索するunitsアクションを設定
・食材選択時に専用の単位をサーバーサイドで検索してフォームにセットできる機能を実装
<img width="638" alt="スクリーンショット 2023-10-29 22 30 00" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/10437386-9557-4d3d-965d-54f4b0c5c015">

・機能実装に伴う一部スタイルの修正

※備考
・食材リストで「希望単位の食材選択」から「純粋な食材選択」になり、リストがスッキリしました。

修正前
<img width="937" alt="スクリーンショット 2023-10-25 18 46 05" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/d4942f2d-28d0-4309-b0ae-af7e22cb2916">

修正後
<img width="760" alt="スクリーンショット 2023-10-29 22 31 44" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/ee939434-40c8-4731-959b-44ff454609ff">


・ユーザーが食材を選択するだけで関連する単位が自動的に設定されるため、ユーザーの操作がより簡単かつ直感的になります。