### PR TITLE
再登録防止の設定を食材フォームに追加

### DIFF
--- a/app/javascript/ingredient_dropdown.js
+++ b/app/javascript/ingredient_dropdown.js
@@ -5,6 +5,7 @@ const searchResultsContainer = document.getElementById('searchResultsContainer')
 const ingredientList = document.getElementById(`ingredient-select`);
 const searchInput = document.getElementById('ingredientSearchInput');
 const ingredient_form = document.getElementById("ingredient_form");
+let validIngredients = [];
 
 document.addEventListener("turbo:load", function() {
   let ingredientName = null;
@@ -103,6 +104,12 @@ document.addEventListener("turbo:load", function() {
   searchResultsContainer.addEventListener("click", function(e) {
     if (!searchResultsContainer) return;
 
+    // validIngredientsに該当する場合、処理をキャンセル
+    if (validIngredients.includes(e.target.textContent.trim())) {
+      e.preventDefault();
+      return false;
+    }
+
     matchedItems = [];
     ingredientName.value = e.target.textContent.trim();
     let parentElement = ingredientName.parentElement;
@@ -147,11 +154,18 @@ function handleSearchResult(itemText) {
   const resultDiv = document.createElement('div');
   resultDiv.textContent = itemText;
   resultDiv.classList.add('search-result-item');
+
+  // validIngredientsの中に該当する値があるかチェック
+  if (validIngredients.includes(itemText)) {
+    resultDiv.style.opacity = '0.5';
+  }
+
   searchResultsContainer.appendChild(resultDiv);
 }
 
 // リストをnoneからblockへ変更
 function showIngredientList() {
+  getAllIngredientTexts()
   ingredientList.style.display = "block";
 }
 
@@ -172,6 +186,7 @@ function closeDropdown() {
   dropdownBg.style.display = "none";
   ingredientList.style.display = "none";
   searchInput.value = "";
+  getAllIngredientTexts()
   clearSearchResults();
 }
 
@@ -188,6 +203,31 @@ function handleIngredientUnitChange(clickedElement) {
     } else {
       inputElement.value = "";
         inputElement.removeAttribute("readonly");
+    }
+  });
+}
+
+// 全てのingredientNameフォームのテキストデータを更新する関数
+function getAllIngredientTexts() {
+  let elements = document.querySelectorAll('.ingredient-name');
+  let values = Array.from(elements).map(element => element.value);
+  validIngredients = values.filter(value => value !== '');
+
+  refreshIngredientList();
+  return validIngredients;
+}
+
+// セットした値を再度入力できないように設定
+function refreshIngredientList() {
+  let ingredients = document.querySelectorAll('[data-value]');
+
+  ingredients.forEach(ingredient => {
+    if (validIngredients.includes(ingredient.getAttribute('data-value'))) {
+        ingredient.style.opacity = '0.5';
+        ingredient.style.pointerEvents = 'none';
+    } else {
+        ingredient.style.color = 'black';
+        ingredient.style.pointerEvents = 'auto';
     }
   });
 }


### PR DESCRIPTION
目的：
食材の再登録を防ぐことで、データの整合性を保てるようにするためです。
また重複して食材を登録する手間をなくすことで、ユーザーがスムーズに操作できるようになります。

内容：
・選択されている食材はリスト上で透過表示にし、選択済みは入力できないと直感的にわかるよう設定
・選択済みの食材にはクリックやタップの操作が無効となるように設定

リストからの選択時の表示画面：
<img width="720" alt="スクリーンショット 2023-10-30 16 08 55" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/12dd400f-05fe-494f-8950-00d6c200d8e9">

検索からの選択時の表示画面：
<img width="492" alt="スクリーンショット 2023-10-30 16 09 08" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/b2858925-a898-49a0-823a-921b359b3ea9">
