### PR TITLE
フォームを調整して食材の複数回設定を許容し、単位の重複を防止

### DIFF
--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -162,7 +162,8 @@
         }
 
         .ingredient-unit{
-          width: 162px;
+          width: 110px;
+          pointer-events: none;
         }
 
         a {

--- a/app/javascript/addForm.js
+++ b/app/javascript/addForm.js
@@ -53,8 +53,7 @@ function createNewForm() {
         <span class="form-number">${paddedNewFormCount}</span>
         <input id="ingredient_name[${newFormCount_back}]" class="ingredient-name" placeholder="食材名を選択" type="text" name="menu[ingredients][${newFormCount_back}][name]" readonly>
         <input type="text" id="ingredient_quantity[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][quantity]" autocomplete="quantity" placeholder="数量" maxlength="4" oninput="this.value = this.value.replace(/[^0-9.]/g, '')" class="ingredient-quantity">
-        <select id="menu_ingredients_unit[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][unit]" class="ingredient-unit">
-          <option value="">食材を選択</option>
+        <select id="menu_ingredients_unit[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][unit]" class="ingredient-unit" tabindex="-1">
         </select>
       </div>`;
 


### PR DESCRIPTION
目的：
献立登録フォームで同一食材の複数回の入力を可能にする一方で、単位の重複登録を防ぐことで献立登録フォームのユーザビリティを向上をさせることが目的です。

内容：
・フォームの入力検証ロジックを更新し、ユーザが同一食材をレシピに複数回追加できるように修正
・ユーザーを混乱させないため、食材選択前には「単位選択のフォーム」をフォーカス、クリックができないよう設定
・食材の単位については同じ単位が複数回選択されないように設定
<img width="666" alt="スクリーンショット 2023-11-08 0 04 19" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/f26c08b9-245a-4c50-80b4-ad2140aefdb5">

・単位選択で「少々」と選択した際に数量が入力できないよう修正
<img width="580" alt="スクリーンショット 2023-11-08 0 04 28" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/90442264-0f82-41ad-97de-f9aaadc9d02b">