### PR TITLE
確認画面用のconfirmアクションを追加

### DIFF
--- a/app/javascript/addForm.js
+++ b/app/javascript/addForm.js
@@ -52,8 +52,9 @@ function createNewForm() {
         </div>
         <span class="form-number">${paddedNewFormCount}</span>
         <input id="ingredient_name[${newFormCount_back}]" class="ingredient-name" placeholder="食材名を選択" type="text" name="menu[ingredients][${newFormCount_back}][name]" readonly>
+        <input type="hidden" id="ingredient_id[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][material_id]", class="hidden-ingredient-id">
         <input type="text" id="ingredient_quantity[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][quantity]" autocomplete="quantity" placeholder="数量" maxlength="4" oninput="this.value = this.value.replace(/[^0-9.]/g, '')" class="ingredient-quantity">
-        <select id="menu_ingredients_unit[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][unit]" class="ingredient-unit" tabindex="-1">
+        <select id="menu_ingredients_unit[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][unit_id]" class="ingredient-unit" tabindex="-1">
         </select>
       </div>`;
 

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -3,9 +3,9 @@ class Ingredient < ApplicationRecord
   belongs_to :material
   belongs_to :unit
 
-  validates :name, presence: true, length: { maximum: 15 }
+  validates :material_id, presence: true, length: { maximum: 15 }
   validates :quantity, presence: true, length: { maximum: 4 }
-  validates :unit, inclusion: { in: ['g', 'kg', 'ml', 'L', '個', '枚', '匹', '切れ', '丁', '杯', '缶', '本', '袋', '束', '合', '大さじ', '小さじ'] }
+  validates :unit_id, presence: true
 
   def validate_unique_name(ingredients)
     if ingredients.map(&:name).uniq.count != ingredients.count

--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -12,7 +12,7 @@
   <div id="main-menu-error" class="menu-error-message"></div>
 
   <div class="menu-registration-input">
-    <%= form_with model: @menu, url: new_confirm_user_menu_path(current_user.id), method: :post, id: "menu_form" do |f| %>
+    <%= form_with model: @menu, url: confirm_user_menu_path(current_user.id), method: :post, id: "menu_form" do |f| %>
 
       <div id="menu-error_name" class="menu-error"></div>
       <div class="name-registration-field">
@@ -58,7 +58,7 @@
                       <ul id="ingredients-list-<%= index %>" style="display: none;">
                         <% materials.each do |material| %>
                           <% if material.material_name %>
-                            <li data-value="<%= material.material_name %>" data-hiragana="<%= material.hiragana %>">
+                            <li data-value="<%= material.id %>" data-hiragana="<%= material.hiragana %>">
                               <%= material.material_name %>
                           <% end %>
                         <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module AutonomyApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    config.active_storage.variant_processor = :mini_magick
 
     # Configuration for the application, engines, and railties goes here.
     #
@@ -22,7 +23,6 @@ module AutonomyApp
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'
-        # resource '/users/:user_id/menus/units', headers: :any, methods: [:post]
         resource '/autocomplete_ingredients', headers: :any, methods: [:post]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     patch 'registrations/update', to: 'custom_registrations#update', as: :update_user_custom_registration
 
 
-    post '/users/:user_id/menus/new_confirm', to: 'menus#new_confirm', as: :new_confirm_user_menu
+    post '/users/:user_id/menus/confirm', to: 'menus#confirm', as: :confirm_user_menu
     post 'users/:user_id/menus/units', to: 'menus#units'
 
 

--- a/db/migrate/20230906091255_create_menus.rb
+++ b/db/migrate/20230906091255_create_menus.rb
@@ -4,7 +4,6 @@ class CreateMenus < ActiveRecord::Migration[7.0]
       t.string :menu_name,               null: false, default: ""
       t.text :menu_contents,             null: false, default: ""
       t.string :contents,                null: false, default: ""
-      t.boolean :original_menu,          null: false, default: false
       t.text :image_meta_data,           null: false, default: ""
       t.string :image,                   null: false, default: ""
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,7 +91,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_110904) do
     t.string "menu_name", default: "", null: false
     t.text "menu_contents", default: "", null: false
     t.string "contents", default: "", null: false
-    t.boolean "original_menu", default: false, null: false
     t.text "image_meta_data", default: "", null: false
     t.string "image", default: "", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
目的：
ユーザーがフォームを入力して送信ボタン（次へ）を押した後、確認画面移行前にバリデーションを行うためです。

内容：
・confirmアクションを menusコントローラに追加
・送信内容に対してバリデーションを設定（app/models/ingredient.rb）
・バリデーションを行う上で必要な情報が不足していたため、JavaScriptとフォーム（view）を一部修正
・menuモデルの不要なカラムを削除
・画像処理に必要なMiniMagickを設定