### PR TITLE
確認画面を作成

### DIFF
--- a/app/assets/stylesheets/menu/menu_confirm.scss
+++ b/app/assets/stylesheets/menu/menu_confirm.scss
@@ -1,0 +1,135 @@
+@import 'shared/menuForm';
+
+.confirm-container{
+  @include menu-container;
+  @media screen and (max-width: 900px) {
+    width: 100%;
+  }
+  .confirm-form-container{
+    width: 70%;
+    @media screen and (max-width: 600px) {
+      width: 100%;
+    }
+    .contents-title{
+      @include contents-title;
+    }
+    .menu-confirm-container{
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-direction: column;
+    }
+
+    .ingredient-confirm-container{
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-direction: column;
+      @media screen and (max-width: 480px) {
+        width: 100%;
+      }
+
+      .ingredients-list {
+        width: 50%;
+        padding-bottom: 30px;
+        @media screen and (max-width: 1400px) {
+          width: 90%;
+        }
+        @media screen and (max-width: 1350px) {
+          width: 70%;
+        }
+        @media screen and (max-width: 900px) {
+          width: 80%;
+        }
+        @media screen and (max-width: 600px) {
+          width: 95%;
+        }
+
+        .ingredient-item {
+          display: flex;
+          justify-content: space-between;
+          align-items: baseline;
+          border-bottom: 1px solid black;
+          padding-bottom: 5px;
+          margin-bottom: 5px;
+        }
+
+        .ingredient-item p {
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+
+        .material-name {
+          flex-basis: 70%;
+        }
+
+        .quantity-unit {
+          display: flex;
+          flex-basis: 30%;
+          justify-content: flex-end;
+        }
+
+        .quantity,
+        .unit {
+          margin-left: 10px;
+        }
+
+        .no-ingredients {
+          text-align: center
+        }
+      }
+    }
+
+    .button-confirm-container{
+      display: block;
+      justify-content: center;
+      align-items: center;
+      @media screen and (max-width: 550px) {
+        width: 100%;
+      }
+
+      .menu-registration-button,
+      .menu-edit-button{
+        width: 50%;
+        padding-top: 10px;
+        margin: auto;
+        @media screen and (max-width: 1540px) {
+          width: 60%;
+        }
+        @media screen and (max-width: 1300px) {
+          width: 70%;
+        }
+        @media screen and (max-width: 1100px) {
+          width: 80%;
+        }
+        @media screen and (max-width: 1000px) {
+          width: 90%;
+        }
+        @media screen and (max-width: 900px) {
+          width: 95%;
+        }
+        @media screen and (max-width: 600px) {
+          width: 100%;
+        }
+      }
+
+      .menu-registration-button input{
+        padding: 10px 45%;
+        font-size: 15px;
+        background-color: #1E9AF4;
+        color: white;
+        border-radius: 20px;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+      }
+
+      .edit-button{
+        padding: 10px 45%;
+        font-size: 15px;
+        background-color: rgb(0, 0, 0);
+        color: rgb(255, 255, 255);
+        border-radius: 20px;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -1,38 +1,24 @@
-.menu-container{
-  display: flex;
-  width: 60%;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+@import 'shared/menuForm';
 
-  background-color: #ffffff;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2);
-  padding: 15px;
-  border-radius: 8px;
-  margin: 0 auto;
-  margin-top: 30px;
-  margin-bottom: 30px;
-  @media screen and (max-width: 800px) {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    box-sizing: border-box;
-    width: 100%;
-    margin: 20px auto 60px;
-    margin-bottom: 60px;
-  }
+.menu-container{
+  @include menu-container;
 
   .contents-title{
-    font-size: 20px;
-    padding-top: 10px;
-    text-decoration: underline;
-    text-align:  center;
+    @include contents-title;
   }
 
   .menu-registration-back-button {
-    width: 45%;
+    width: 80%;
     margin: 0 auto;
+    @media screen and (max-width: 1540px) {
+      width: 70%;
+    }
+    @media screen and (max-width: 1300px) {
+      width: 80%;
+    }
+    @media screen and (max-width: 1100px) {
+      width: 90%;
+    }
   }
 
   .back-button{
@@ -108,9 +94,18 @@
     }
 
     .menu-registration-actions {
-      width: 45%;
+      width: 80%;
       margin: 0 auto;
       margin-top: 40px;
+      @media screen and (max-width: 1540px) {
+        width: 70%;
+      }
+      @media screen and (max-width: 1300px) {
+        width: 80%;
+      }
+      @media screen and (max-width: 1100px) {
+        width: 90%;
+      }
     }
 
     .menu-registration-actions input{
@@ -285,7 +280,7 @@
       }
     }
 
-  .count-up-botton{
+  .count-up-button{
     button{
       width: 200px;
       background-color: #f99d68;

--- a/app/assets/stylesheets/shared/_menuForm.scss
+++ b/app/assets/stylesheets/shared/_menuForm.scss
@@ -1,0 +1,33 @@
+// 登録編集のフォームの大枠で使用します
+@mixin menu-container {
+  display: flex;
+  width: 60%;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  background-color: #ffffff;
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2);
+  padding: 15px;
+  border-radius: 8px;
+  margin: 0 auto;
+  margin-top: 30px;
+  margin-bottom: 30px;
+  @media screen and (max-width: 800px) {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    box-sizing: border-box;
+    width: 100%;
+    margin: 20px auto 60px;
+    margin-bottom: 60px;
+  }
+}
+
+@mixin contents-title{
+  font-size: 20px;
+  padding-top: 10px;
+  text-decoration: underline;
+  text-align:  center;
+}

--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -71,7 +71,7 @@
           </div>
         </div>
 
-        <div class="count-up-botton">
+        <div class="count-up-button">
           <button class="form-count-up" data-action="increment" id="form-count-up"><span id="formCountLimit"></span></button>
         </div>
       </div>

--- a/app/views/menus/confirm.html.erb
+++ b/app/views/menus/confirm.html.erb
@@ -1,0 +1,89 @@
+
+<div class="confirm-container">
+  <div class="confirm-form-container">
+    <%= form_with model: [@user, @menu], local: true do |f| %>
+      <div class="menu-confirm-container">
+        <div class="menu-confirm-title">
+          <h1>登録内容の最終確認</h1>
+        </div>
+
+        <div class ="contents-title">
+          <p>　献立名　</p>
+        </div>
+        <div class ="menu-contents">
+          <%= @menu.menu_name %>
+          <%= f.hidden_field :menu_name, value: @menu.menu_name %>
+        </div>
+
+        <div class ="contents-title">
+          <p>　献立内容　</p>
+        </div>
+        <div class ="menu-contents">
+          <%= @menu.menu_contents %>
+          <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
+        </div>
+
+        <div class ="contents-title">
+          <p>　作り方　</p>
+        </div>
+        <div class ="menu-contents">
+          <%= simple_format(sanitize(@menu.contents)) %>
+          <%= f.hidden_field :contents, value: @menu.contents %>
+        </div>
+
+        <div class ="contents-title">
+          <p>　献立画像　</p>
+        </div>
+        <div class ="menu-contents">
+          <% if @image_data_url.present? %>
+            <img src="<%= @image_data_url %>" width="300" height="200" alt="uploaded image preview" />
+            <%= f.hidden_field :encoded_image, value: @encoded_image %>
+            <%= f.hidden_field :image_content_type, value: @menu.image.content_type %>
+          <% else %>
+            <p>画像なし</p>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="ingredient-confirm-container">
+        <div class ="contents-title">
+          <p>　食材リスト　</p>
+        </div>
+
+        <div class="ingredients-list">
+          <% if @menu.ingredients.present? %>
+            <% @menu.ingredients.each_with_index do |ingredient, index| %>
+              <div class="ingredient-item">
+                <p class="material-name"><%= ingredient.material.material_name %></p>
+                <div class="quantity-unit">
+                  <p class="quantity"><%= ingredient.quantity %></p>
+                  <p class="unit"><%= ingredient.unit.unit_name %></p>
+                </div>
+
+                <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
+                <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
+                <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
+              </div>
+            <% end %>
+          <% else %>
+            <p class="no-ingredients">食材はありません</p>
+          <% end %>
+        </div>
+      </div>
+
+
+      <div class="button-confirm-container">
+        <div class="menu-registration-button">
+          <%= f.submit "登録", name: "commit" %>
+        </div>
+        <div class="menu-edit-button">
+          <% if @menu.new_record? %>
+            <%= button_to "戻る", new_user_menu_path(@user, { some_field: @menu }), class: "edit-button" %>
+          <% else %>
+            <%= button_to "戻る", edit_user_menu_path(@user, @menu, { some_field: @menu }), class: "edit-button" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
目的：
献立登録プロセスの最終段階において、ユーザーが入力した内容を確認できる画面を追加することです。これにより、ユーザーが間違いなく、意図した通りに献立を登録できるようになります。

内容：
・確認画面の追加
・画像と食材はセットされていない場合はセットされていない旨の文言が表示されるよう設定
・確認画面用スタイルの適応

<img width="909" alt="スクリーンショット 2023-11-13 23 06 41" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/0a3f9ccb-5a75-4d2e-828b-26970a9f5349">
<img width="935" alt="スクリーンショット 2023-11-13 23 06 47" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/cb5c378d-1208-41fb-95bb-c7a9798ae043">