### PR TITLE
単位フォームにおける不適切なイベント発火の問題を修正

### DIFF
--- a/app/javascript/ingredient_dropdown.js
+++ b/app/javascript/ingredient_dropdown.js
@@ -177,11 +177,14 @@ function closeDropdown() {
   clearSearchResults();
 }
 
-// ingredient_quantityに「少々」がセットされた時の処理
+// ingredient_unitに値が変更された時の処理
 function handleIngredientUnitChange(clickedElement) {
   clickedElement.addEventListener('change', function() {
+    if (clickedElement.selectedIndex < 0) return;
     const selectedOptionText = clickedElement.options[clickedElement.selectedIndex].textContent;
     const inputElement = clickedElement.closest('div').querySelector(".ingredient-quantity");
+
+    // ingredient_unitに「少々」がセットされた時の処理
     if (selectedOptionText === "少々") {
       inputElement.style.backgroundColor = "#e0e0e0";
       inputElement.style.pointerEvents = "none";


### PR DESCRIPTION
目的：
登録フォーム表示時に発生していた単位フォームのイベント誤発火問題を修正することが目的です。

内容：
・登録フォームを表示時に「単位フォーム」に値が入っていないことでエラーが発生していたため、値が入っている場合のみ起動するように修正
