### PR TITLE
献立を本登録するcreateアクションを設定

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -45,6 +45,27 @@ class MenusController < ApplicationController
     render json: units
   end
 
+  def create
+    menu = Menu.new(menu_params.except(:image))
+    new_ingredient_forms(menu, params[:menu][:ingredients])
+
+    if !params[:menu][:encoded_image].nil?
+      image_data = Base64.decode64(params[:menu][:encoded_image])
+      filename = "user_#{current_user.id}の献立の画像"
+      menu.image.attach(io: StringIO.new(image_data), filename: filename, content_type: menu.image.content_type)
+    end
+
+    menu.save
+    menu.ingredients.each do |ingredient|
+      if ingredient.save
+        MenuIngredient.create(menu_id: menu.id, ingredient_id: ingredient.id)
+        UserMenu.create(menu_id: menu.id, user_id: current_user.id)
+      end
+    end
+
+      redirect_to user_menus_path
+  end
+
   private
 
   def menu_params

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -56,10 +56,10 @@ class MenusController < ApplicationController
     end
 
     menu.save
+    UserMenu.create(menu_id: menu.id, user_id: current_user.id)
     menu.ingredients.each do |ingredient|
       if ingredient.save
         MenuIngredient.create(menu_id: menu.id, ingredient_id: ingredient.id)
-        UserMenu.create(menu_id: menu.id, user_id: current_user.id)
       end
     end
 


### PR DESCRIPTION
目的：
献立登録機能におけるCreateアクションの実装を行うことです。この実装により、ユーザーが献立情報をアプリケーションに登録し、その情報をユーザーのアカウントおよび関連する食材情報と紐付けることが可能になります。

内容：
・ユーザーがアップロードした献立の画像データをBase64形式で受け取り、デコードしてメニューの画像としてアタッチ
・新しく作成された献立情報を、現在ログインしているユーザー（current_user）と関連付け
・ユーザーから提供されたingredientデータをmenuに関連付け、MenuIngredientテーブルに情報を登録