### PR TITLE
@menuインスタンス生成時のcurrent_user使用削除による単純化

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -15,7 +15,6 @@ class MenusController < ApplicationController
 
 
   def confirm
-    @user = current_user
     @menu = Menu.new(menu_params)
 
     if params[:menu][:ingredients].present?

--- a/app/views/menus/confirm.html.erb
+++ b/app/views/menus/confirm.html.erb
@@ -1,7 +1,7 @@
 
 <div class="confirm-container">
   <div class="confirm-form-container">
-    <%= form_with model: [@user, @menu], local: true do |f| %>
+    <%= form_with model: [current_user, @menu], local: true do |f| %>
       <div class="menu-confirm-container">
         <div class="menu-confirm-title">
           <h1>登録内容の最終確認</h1>
@@ -78,9 +78,9 @@
         </div>
         <div class="menu-edit-button">
           <% if @menu.new_record? %>
-            <%= button_to "戻る", new_user_menu_path(@user, { some_field: @menu }), class: "edit-button" %>
+            <%= button_to "戻る", new_user_menu_path(current_user, { some_field: @menu }), class: "edit-button" %>
           <% else %>
-            <%= button_to "戻る", edit_user_menu_path(@user, @menu, { some_field: @menu }), class: "edit-button" %>
+            <%= button_to "戻る", edit_user_menu_path(current_user, @menu, { some_field: @menu }), class: "edit-button" %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
目的：
@menu インスタンスの生成プロセスを単純化し、コードの可読性とメンテナンス性を向上させる目的です。

内容：
・current_user を使用して @menu インスタンスを生成していましたが、これが実際には必要ないことが確認されたため、この参照を削除
※これにより@menu の生成ロジックがより単純で理解しやすくなり、将来的な変更やデバッグが容易になります。