### PR TITLE
unit_idが17（少々）の場合にquantityのnilを許容するカスタムバリデーションを追加

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -4,17 +4,13 @@ class Ingredient < ApplicationRecord
   belongs_to :unit
 
   validates :material_id, presence: true, length: { maximum: 15 }
-  validates :quantity, presence: true, length: { maximum: 4 }
+  validates :quantity, presence: true, length: { maximum: 4 }, unless: :skip_quantity_validation?
   validates :unit_id, presence: true
 
-  def validate_unique_name(ingredients)
-    if ingredients.map(&:name).uniq.count != ingredients.count
-      Rails.logger.info '名前にかぶりがあったよ'
-      return false
-    end
+  private
 
-    Rails.logger.info '名前にかぶりなかったよ'
-    return true
+  def skip_quantity_validation?
+    unit_id == 17
   end
 
 end


### PR DESCRIPTION
目的：
特定のケース（unit_idが17の場合）において、quantity フィールドのnilを許容するためのカスタムバリデーションの追加を目的としています。

内容：
・モデルにカスタムバリデーションメソッド skip_quantity_validation? を追加
・quantity に対する存在性と長さのバリデーションは、unit_id が17の場合にのみスキップされるように設定