### PR TITLE
食材登録時の単位重複を許容し、確認画面での合算表示を可能にする機能を追加

### DIFF
--- a/app/javascript/ingredient_dropdown.js
+++ b/app/javascript/ingredient_dropdown.js
@@ -206,8 +206,6 @@ function handleIngredientUnitChange(clickedElement) {
       inputElement.removeAttribute("tabindex");
       inputElement.placeholder = "数量";
     }
-
-    updateAndRerunProcesses()
   });
 }
 
@@ -241,45 +239,6 @@ function handleIngredientNameChange(selectElement, value) {
       selectElement.appendChild(option);
       selectElement.style.pointerEvents = 'auto';
       selectElement.removeAttribute('tabindex');
-      updateAndRerunProcesses()
-    });
-  });
-}
-
-// すべてのユニットオプションをリセットし、各食材名に対してユニットオプションを更新する
-function updateAndRerunProcesses() {
-  const ingredientNames = document.querySelectorAll('.ingredient-name');
-
-  // すべてのユニットオプションをリセットする
-  document.querySelectorAll('.ingredient-unit option').forEach(option => {
-    option.disabled = false;
-    option.style.opacity = "1";
-  });
-
-  // 各食材名に対してユニットオプションを更新する
-  ingredientNames.forEach(ingredientElement => {
-    if (ingredientElement.value.trim() === "") return;
-
-    let parentElement = ingredientElement.parentElement;
-    const selectedIngredient = ingredientElement.value;
-    const unitElement = parentElement.querySelector(".ingredient-unit");
-    const selectedUnit = unitElement.value;
-
-    // 同じ食材名を持つ要素を取得
-    const matchingIngredients = Array.from(ingredientNames).filter(elem => elem !== ingredientElement && elem.value === selectedIngredient);
-    // 対応するユニットオプションを無効にし、必要に応じて値をリセットする
-    matchingIngredients.forEach(matchingIngredient => {
-      const parentElement = matchingIngredient.parentElement;
-      const unitElement = parentElement.querySelector(".ingredient-unit");
-      const optionElems = Array.from(unitElement.querySelectorAll('option'));
-
-      optionElems.forEach(option => {
-        if (option.value !== selectedUnit) return;
-        option.disabled = true;
-        option.style.opacity = "0.5";
-        if (unitElement.value !== selectedUnit) return;
-        unitElement.value = "";
-      });
     });
   });
 }

--- a/app/views/menus/confirm.html.erb
+++ b/app/views/menus/confirm.html.erb
@@ -51,22 +51,24 @@
         </div>
 
         <div class="ingredients-list">
-          <% if @menu.ingredients.present? %>
-            <% @menu.ingredients.each_with_index do |ingredient, index| %>
+          <% if @aggregated_ingredients.present? %>
+            <% @aggregated_ingredients.each do |aggregated_ingredient| %>
               <div class="ingredient-item">
-                <p class="material-name"><%= ingredient.material.material_name %></p>
+                <p class="material-name"><%= aggregated_ingredient.material.material_name %></p>
                 <div class="quantity-unit">
-                  <p class="quantity"><%= ingredient.quantity %></p>
-                  <p class="unit"><%= ingredient.unit.unit_name %></p>
+                  <p class="quantity"><%= aggregated_ingredient.quantity %></p>
+                  <p class="unit"><%= aggregated_ingredient.unit.unit_name %></p>
                 </div>
-
-                <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
-                <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
-                <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
               </div>
             <% end %>
           <% else %>
             <p class="no-ingredients">食材はありません</p>
+          <% end %>
+
+          <% @menu.ingredients.each_with_index do |ingredient, index| %>
+            <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
+            <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
+            <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
目的：
食材登録機能のユーザビリティ向上とデータ処理の最適化

内容：
・ユーザーが同一食材を異なる単位で複数回登録できるように、フォームの入力規則を変更
・システム内に「合算用の単位」とその「変換率」をあらかじめ設定し、異なる単位で登録された同一食材の量を適切に合算できるように設定
・確認画面では合算データを表示できるよう修正
※合算データは表示用のためdbには合算前の形式で登録されます。


備考：
従来のシステムでは、レシピに従った食材の登録が不便でした。特に、同じ食材を異なるシーンで複数回登録する必要がある場合、ユーザーは登録リストを行き来する必要がありました。
新しいシステムでは、ユーザーが同じ食材を何度でも登録できるようにし、確認画面でこれらを合算して表示します。これにより、レシピの流れに沿った効率的な登録が可能となり、最終的な食材リストが簡潔かつ明瞭になります。