### PR TITLE
献立登録時に画像プレビューが出るように改善

### DIFF
--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -63,6 +63,13 @@
         color: rgb(250, 43, 43);
         text-align: center;
       }
+
+      .image-preview-container{
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
     }
 
     .name-registration-field input,
@@ -289,19 +296,19 @@
       }
     }
 
-  .count-up-button{
-    button{
-      width: 200px;
-      background-color: #f99d68;
-      border: #2c2c2c;
-      padding: 2%;
-      font-size: 15px;
-      color: #000000;
-      margin-top: 10px;
-      margin-bottom: 5px;
-      cursor: pointer;
+    .count-up-button{
+      button{
+        width: 200px;
+        background-color: #f99d68;
+        border: #2c2c2c;
+        padding: 2%;
+        font-size: 15px;
+        color: #000000;
+        margin-top: 10px;
+        margin-bottom: 5px;
+        cursor: pointer;
+      }
     }
-  }
   }
 }
 

--- a/app/javascript/image_preview.js
+++ b/app/javascript/image_preview.js
@@ -1,7 +1,7 @@
 createPreview()
 
 function createPreview() {
-  var imageInput = document.getElementById('menu_image');
+  let imageInput = document.getElementById('menu_image');
 
   if (!imageInput) return;
 

--- a/app/javascript/image_preview.js
+++ b/app/javascript/image_preview.js
@@ -2,22 +2,25 @@ createPreview()
 
 function createPreview() {
   var imageInput = document.getElementById('menu_image');
-  console.log(imageInput);
 
   if (imageInput) {
     imageInput.addEventListener('change', function(event) {
+      // ユーザーが選択したファイルを取得
       let file = event.target.files[0];
+      // Base64エンコードされたデータURLおを作成して格納
       let reader = new FileReader();
 
       reader.onload = function(e) {
         let imagePreview = document.getElementById('image-preview');
 
         if (imagePreview) {
+          // Base64エンコードされたデータURLをsrc属性に代入
           imagePreview.src = e.target.result;
           imagePreview.style.display = 'block';
         }
       };
 
+      // 画像データを取得するための命令
       reader.readAsDataURL(file);
     });
   }

--- a/app/javascript/image_preview.js
+++ b/app/javascript/image_preview.js
@@ -1,0 +1,24 @@
+createPreview()
+
+function createPreview() {
+  var imageInput = document.getElementById('menu_image');
+  console.log(imageInput);
+
+  if (imageInput) {
+    imageInput.addEventListener('change', function(event) {
+      let file = event.target.files[0];
+      let reader = new FileReader();
+
+      reader.onload = function(e) {
+        let imagePreview = document.getElementById('image-preview');
+
+        if (imagePreview) {
+          imagePreview.src = e.target.result;
+          imagePreview.style.display = 'block';
+        }
+      };
+
+      reader.readAsDataURL(file);
+    });
+  }
+}

--- a/app/javascript/image_preview.js
+++ b/app/javascript/image_preview.js
@@ -3,25 +3,23 @@ createPreview()
 function createPreview() {
   var imageInput = document.getElementById('menu_image');
 
-  if (imageInput) {
-    imageInput.addEventListener('change', function(event) {
-      // ユーザーが選択したファイルを取得
-      let file = event.target.files[0];
-      // Base64エンコードされたデータURLおを作成して格納
-      let reader = new FileReader();
+  if (!imageInput) return;
 
-      reader.onload = function(e) {
-        let imagePreview = document.getElementById('image-preview');
+  imageInput.addEventListener('change', function(event) {
+    // ユーザーが選択したファイルを取得
+    let file = event.target.files[0];
+    // Base64エンコードされたデータURLを作成して格納
+    let reader = new FileReader();
 
-        if (imagePreview) {
-          // Base64エンコードされたデータURLをsrc属性に代入
-          imagePreview.src = e.target.result;
-          imagePreview.style.display = 'block';
-        }
-      };
+    reader.onload = function(e) {
+      let imagePreview = document.getElementById('image-preview');
 
-      // 画像データを取得するための命令
-      reader.readAsDataURL(file);
-    });
-  }
+      // Base64エンコードされたデータURLをsrc属性に代入
+      imagePreview.src = e.target.result;
+      imagePreview.style.display = 'block';
+    };
+
+    // 画像データを取得するための命令
+    reader.readAsDataURL(file);
+  });
 }

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -31,11 +31,14 @@
         </div>
 
         <div class="image-registration-field">
-          <%= f.file_field :image, autofocus: true, autocomplete: "image", placeholder: "献立の写真" %>
+          <%= f.file_field :image, autofocus: true, autocomplete: "image", placeholder: "献立の写真", id: "menu_image" %>
+        </div>
+
+        <div class="image-preview-container">
+          <img id="image-preview" src="<%= @image_data_url if @image_data_url.present? %>" width="300" height="200" alt="uploaded image preview" style="<%= 'display: none;' unless @image_data_url.present? %>" />
         </div>
 
         <% if @image_data_url.present? %>
-          <img src="<%= @image_data_url %>" width="300" height="200" alt="uploaded image preview" />
           <%= f.hidden_field :encoded_image, value: @encoded_image %>
           <%= f.hidden_field :image_content_type, value: params[:menu][:image_content_type] %>
           <%= f.hidden_field :image_data_url, value: @image_data_url %>
@@ -105,3 +108,4 @@
   <%= javascript_include_tag 'addForm' %>
   <%= javascript_include_tag 'ingredient_dropdown' %>
   <%= javascript_include_tag 'menu_validation' %>
+  <%= javascript_include_tag 'image_preview' %>


### PR DESCRIPTION
目的：
献立登録フォームにおいて、ユーザがアップロードする画像をリアルタイムで確認できるようにし、直感的な操作性を向上させることが目的です。

内容：
・ユーザが選択した画像のプレビューを生成する`createPreview`関数を実装
・献立登録フォームに画像プレビュー用の<img>タグを追加
・CSSを用いて、プレビュー画像がフォーム内で適切にスタイリングされるように調整

<img width="984" alt="スクリーンショット 2023-11-25 21 38 27" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/0766e1d6-fa18-46b9-bc75-1562f02ce678">
