### PR TITLE
メニュー表示のUIを改善

### DIFF
--- a/app/assets/stylesheets/menu/menu_list.scss
+++ b/app/assets/stylesheets/menu/menu_list.scss
@@ -1,6 +1,7 @@
 .menus-container{
   text-align: center;
   width: 100%;
+  justify-content: center;
   @media screen and (max-width: 600px) {
     text-align: center;
   }
@@ -36,13 +37,41 @@
       }
     }
 
-    .original_menus_list {
-      @extend .rounded-image;
-    }
-  }
+    .original_menus_list,
+    .default-menus-list{
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-around;
+      padding-top: 50px;
+      gap: 10px;
+      align-items: stretch;
+      justify-content: center;
 
-  .default-menus-list{
-    @extend .rounded-image;
+      .menu-item {
+        width: 250px;
+        height: 250px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        background-color: #f8f8f8;
+        border: 1px solid #ddd;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        border-radius: 8px;
+        border-radius: 20px;
+        margin-right: 10px;
+        margin-bottom: 10px;
+        cursor: pointer;
+      }
+
+      .menu-item-title {
+        margin-top: 10px;
+      }
+
+      .rounded-image {
+        border-radius: 20px;
+      }
+    }
   }
 }
 
@@ -70,7 +99,7 @@
   background-color: #000000;
 }
 
-.rounded-image {
-  margin: 10px 5px;
-  border-radius: 11%;
-}
+// .rounded-image {
+//   margin: 10px 5px;
+//   border-radius: 11%;
+// }

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -10,7 +10,10 @@
     <div class="original_menus_list">
       <% if @original_menus.any? %>
         <% @original_menus.each do |menu| %>
-          <%= image_tag(rails_blob_path(menu.image.variant(resize_to_limit: [200, 200])), class: "rounded-image") %>
+          <div class="menu-item">
+            <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+            <div class="menu-item-title"><%= menu.menu_name %></div>
+          </div>
         <% end %>
       <% end %>
     </div>
@@ -20,7 +23,10 @@
 
   <div class ="default-menus-list">
     <% @default_menus.each do |menu| %>
-      <%= image_tag(rails_blob_path(menu.image.variant(resize_to_limit: [200, 200])), class: "rounded-image") %>
+      <div class="menu-item">
+        <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+        <div class="menu-item-title"><%= menu.menu_name %></div>
+      </div>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
目的：
メニューの表示方法をより直感的かつ使いやすいデザインに改善することです。ユーザーが各メニュー項目を簡単に識別し、選択できるようにすることで、サイトのナビゲーションを向上させます。

内容：
・メニュー項目の画像を `resize_to_fill` メソッドに変更し、画像がコンテンツ領域に適切にフィットするよう調整
・各メニュー項目の下に食材名を表示するように変更
・メニュー項目にホバー時にカーソルが指マークに変わるスタイルを適用

<img width="1420" alt="スクリーンショット 2023-11-27 15 43 49" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/8cee948c-27e3-4f85-a8b2-095b1c434eb2">
<img width="491" alt="スクリーンショット 2023-11-27 15 44 20" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/a2723351-b7b3-49f6-aefe-7399295ee08d">