### PR TITLE
オリジナル献立と標準献立のページを分割して、UIを改善

### DIFF
--- a/app/assets/stylesheets/menu/menu_list.scss
+++ b/app/assets/stylesheets/menu/menu_list.scss
@@ -38,7 +38,7 @@
     }
 
     .original_menus_list,
-    .default-menus-list{
+    .sample-menus-list{
       display: flex;
       flex-wrap: wrap;
       justify-content: space-around;
@@ -111,11 +111,32 @@
     }
 
   }
+
+  /* 戻るボタンのスタイル */
+  .back-button {
+    display: block;
+    margin: 50px auto;
+    padding: 15px 0;
+    width: 30%;
+    font-size: 18px;
+    text-align: center;
+    background-color: #000;
+    color: white;
+    border: none;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    @media screen and (max-width: 800px) {
+      width: 80%;
+  }
+  }
+
+
 }
 
 .menu-heading {
   display: block;
-  margin-top: 80px;
+  margin-top: 50px;
   font-size: 30px;
   position: relative;
   display: inline-block;

--- a/app/assets/stylesheets/user-index.scss
+++ b/app/assets/stylesheets/user-index.scss
@@ -1,30 +1,41 @@
 .button-set-container {
+  display: block;
   position: fixed;
   bottom: 20px;
   width: 100%;
   text-align: center;
 
-  .menu-list-button{
-    @extend .home-page-button-style;
-  }
-
-  .shoppingList-button{
-    @extend .home-page-button-style;
-  }
-}
-
-
-.home-page-button-style {
-  margin-top: 10px;
-  padding: 10px 10%;
-  font-size: 15px;
-  background-color: #000000;
-  color: white;
-  border-radius: 20px;
-  // white-space: nowrap;
-
-  @media screen and (max-width: 400px) {
+  .button-style {
     margin-top: 10px;
-    width: 90%;
+    padding: 10px 0;
+    width: 30%;
+    font-size: 15px;
+    color: white;
+    border-radius: 20px;
+    display: inline-block;
+    box-sizing: border-box;
+    text-align: center;
+  }
+
+  /* ボタンの背景色クラス */
+  .bg-custom-menu {
+    background-color: #555;
+  }
+
+  .bg-standard-menu {
+    background-color: #777;
+  }
+
+  .bg-shopping-list {
+    background-color: #333;
+    height: 60px;
+    margin-top: 20px;
+    font-size: 25px;
+  }
+
+  @media screen and (max-width: 800px) {
+    .button-style {
+      width: 80%;
+    }
   }
 }

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,8 +1,13 @@
 class MenusController < ApplicationController
 
-  def index
+  def custom_menus
     menu_ids = UserMenu.where(user_id: current_user.id).pluck(:menu_id)
     @original_menus = Menu.where(id: menu_ids).page(params[:page]).per(10)
+  end
+
+
+  def sample_menus
+    menu_ids = UserMenu.where(user_id: current_user.id).pluck(:menu_id)
     @default_menus = Menu.where.not(id: UserMenu.pluck(:menu_id)).page(params[:page]).per(10)
   end
 

--- a/app/views/menus/custom_menus.html.erb
+++ b/app/views/menus/custom_menus.html.erb
@@ -1,10 +1,10 @@
 <%= render 'shared/menu' %>
 
-<div class ="menus-container">
+<div class="menus-container">
 
   <h3 class="original-menu-heading">オリジナル献立</h3>
 
-  <div class ="menus_list">
+  <div class="menus_list">
     <%= button_to "オリジナル献立作成", new_user_menu_path(current_user.id), class: "original-menu-button", method: :get %>
 
     <div class="original_menus_list">
@@ -23,20 +23,5 @@
     </div>
   </div>
 
-  <h3 class="menu-list-heading">標準献立</h3>
-
-  <div class ="menus_list">
-    <div class ="default-menus-list">
-      <% @default_menus.each do |menu| %>
-        <div class="menu-item">
-          <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
-          <div class="menu-item-title"><%= menu.menu_name %></div>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="pagination-container">
-      <%= paginate @default_menus %>
-    </div>
-  </div>
+  <%= button_to "戻る", root_path, class: "back-button", method: :get %>
 </div>

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -96,7 +96,7 @@
       <% end %>
 
       <div class="menu-registration-back-button">
-        <%= button_to "戻る", user_menus_path, class: "back-button", id: "back_button", method: :get %>
+        <%= button_to "戻る", user_custom_menus_path, class: "back-button", id: "back_button", method: :get %>
       </div>
 
     </div>

--- a/app/views/menus/sample_menus.html.erb
+++ b/app/views/menus/sample_menus.html.erb
@@ -1,0 +1,25 @@
+<%= render 'shared/menu' %>
+
+<div class="menus-container">
+
+  <h3 class="menu-list-heading">標準献立</h3>
+
+  <div class ="menus_list">
+    <% if @default_menus.any? %>
+      <div class ="sample-menus-list">
+        <% @default_menus.each do |menu| %>
+          <div class="menu-item">
+            <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+            <div class="menu-item-title"><%= menu.menu_name %></div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="pagination-container">
+      <%= paginate @default_menus %>
+    </div>
+
+    <%= button_to "戻る", root_path, class: "back-button", method: :get %>
+  </div>
+</div>

--- a/app/views/menus/sample_menus.html.erb
+++ b/app/views/menus/sample_menus.html.erb
@@ -2,7 +2,7 @@
 
 <div class="menus-container">
 
-  <h3 class="menu-list-heading">標準献立</h3>
+  <h3 class="menu-list-heading">サンプル献立</h3>
 
   <div class ="menus_list">
     <% if @default_menus.any? %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,10 +1,7 @@
 <%= render 'shared/menu' %>
 
 <div class="button-set-container">
-  <%= button_to "献立リスト追加", user_menus_path(current_user.id), class: "menu-list-button", method: :get %>
-  <%= button_to "買い出しに行く", root_path, method: :get , class: "shoppingList-button"%>
-
-  <!-- 下記のリダイレクト先が完成次第、下記のコードに切り替えてください。（＃を取るのを忘れずに） -->
-  <%#= button_to "献立リスト追加", user_menus_path(current_user.id), class: "menu-list-button", method: :get %>
-  <%#= button_to "買い出しに行く", user_menus_path(current_user.id), class: "shoppingList-button", method: :get %>
+  <%= button_to "オリジナル献立リスト", user_custom_menus_path(current_user), class: "button-style bg-custom-menu", method: :get %>
+  <%= button_to "サンプル献立リスト", sample_menus_path, class: "button-style bg-standard-menu", method: :get %>
+  <%= button_to "買い出しに行く", root_path, class: "button-style bg-shopping-list", method: :get %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,11 @@ Rails.application.routes.draw do
   get 'users/:id/my_page', to: 'users#my_page', as: :user_my_page
   post '/users/:user_id/menus/confirm', to: 'menus#confirm', as: :confirm_user_menu
   post 'users/:user_id/menus/units', to: 'menus#units'
+  # ユーザーが作成した献立用のルーティング
+  get 'users/:user_id/custom_menus', to: 'menus#custom_menus', as: :user_custom_menus
+  # 標準献立用のルーティング
+  get 'sample_menus', to: 'menus#sample_menus', as: :sample_menus
+
 
   devise_for :users
   devise_scope :user do


### PR DESCRIPTION
目的：
ユーザーがオリジナル献立とサンプル献立をより簡単に閲覧できるように、それぞれの献立を別々のページで表示するようにすることが目的です。

内容：
・オリジナル献立とサンプル献立を表示するための新しいルーティングを設定
・MenusController に original_menus と sample_menus アクションを追加
・オリジナル献立とサンプル献立のそれぞれに対応するビューファイルを新規作成
・ユーザーインターフェースを向上させるため、ページネーションを各ページに分けて実装

<img width="1419" alt="スクリーンショット 2023-11-28 12 40 14" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/4f6e3e09-0dfc-46fd-a604-441c07d98069">
<img width="1411" alt="スクリーンショット 2023-11-28 13 00 43" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/6067ac44-528c-4343-8e44-c50cb0dee93a">
<img width="1408" alt="スクリーンショット 2023-11-28 12 55 27" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/822ef2cf-b4d9-4f36-b40a-187d26d2298b">
