### PR TITLE
献立一覧から詳細ページへのリンク機能の追加とビュースタイルの更新

### DIFF
--- a/app/assets/stylesheets/edit_custom_registration.scss
+++ b/app/assets/stylesheets/edit_custom_registration.scss
@@ -40,17 +40,6 @@
     border-radius: 20px;
     border: 1px solid rgba(0, 0, 0, 0.2);
     white-space: nowrap;
-    @media screen and (max-width: 400px) {
-      margin-top: 10px;
-      margin-left: 5px;
-      padding: 10px 40%;
-      font-size: 15px;
-      background-color: #000000;
-      color: white;
-      border-radius: 20px;
-      border: 1px solid rgba(0, 0, 0, 0.2);
-      white-space: nowrap;
-    }
   }
 
 }

--- a/app/assets/stylesheets/menu/menu_list.scss
+++ b/app/assets/stylesheets/menu/menu_list.scss
@@ -1,3 +1,5 @@
+@import 'shared/styles';
+
 .menus-container{
   text-align: center;
   width: 100%;
@@ -65,8 +67,14 @@
         cursor: pointer;
       }
 
+      .menu-item-link, .menu-item-link:visited, .menu-item-link:hover, .menu-item-link:active {
+        text-decoration: none;
+      }
+
       .menu-item-title {
         margin-top: 10px;
+        color: black;
+        text-decoration: none;
       }
 
       .rounded-image {
@@ -115,24 +123,8 @@
 
   /* 戻るボタンのスタイル */
   .back-button {
-    display: block;
-    margin: 50px auto;
-    padding: 15px 0;
-    width: 30%;
-    font-size: 18px;
-    text-align: center;
-    background-color: #000;
-    color: white;
-    border: none;
-    border-radius: 25px;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-    @media screen and (max-width: 800px) {
-      width: 80%;
+    @include back-button;
   }
-  }
-
-
 }
 
 .menu-heading {

--- a/app/assets/stylesheets/menu/menu_show.scss
+++ b/app/assets/stylesheets/menu/menu_show.scss
@@ -1,0 +1,76 @@
+@import 'shared/styles';
+@import 'shared/menuForm';
+
+.menu-show-container{
+  @include menu-container;
+  @media screen and (max-width: 900px) {
+    width: 100%;
+  }
+
+  .menu-detail-container{
+    width: 70%;
+    @media screen and (max-width: 600px) {
+      width: 100%;
+    }
+    .menu-show-list{
+      @include flex-center-column;
+      .show-contents-title{
+        @include contents-title;
+      }
+
+    }
+
+    .ingredient-show-container{
+      @include flex-center-column;
+      @media screen and (max-width: 480px) {
+        width: 100%;
+      }
+
+      .ingredients-show-list {
+        width: 50%;
+        padding-bottom: 30px;
+        @media screen and (max-width: 1400px) {
+          width: 95%;
+        }
+
+        .ingredient-show-item {
+          display: flex;
+          justify-content: space-between;
+          align-items: baseline;
+          border-bottom: 1px solid black;
+          padding-bottom: 5px;
+          margin-bottom: 5px;
+        }
+
+        .ingredient-show-item p {
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+
+        .material-name {
+          flex-basis: 70%;
+        }
+
+        .quantity-unit {
+          display: flex;
+          flex-basis: 30%;
+          justify-content: flex-end;
+        }
+
+        .quantity,
+        .unit {
+          margin-left: 10px;
+        }
+
+        .no-ingredients {
+          text-align: center
+        }
+      }
+    }
+  }
+
+  .back-button{
+    @include back-button;
+    width: 45%;
+  }
+}

--- a/app/assets/stylesheets/shared/_styles.scss
+++ b/app/assets/stylesheets/shared/_styles.scss
@@ -90,3 +90,21 @@
     font-size: 10px;
   }
 }
+
+@mixin back-button {
+  display: block;
+  margin: 50px auto;
+  padding: 15px 0;
+  width: 30%;
+  font-size: 18px;
+  text-align: center;
+  background-color: #000;
+  color: white;
+  border: none;
+  border-radius: 25px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  @media screen and (max-width: 800px) {
+    width: 80%;
+  }
+}

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -151,6 +151,16 @@ class MenusController < ApplicationController
     redirect_to user_menus_path
   end
 
+
+  def show
+    @menu = Menu.find(params[:id])
+
+    # 重複した献立を基準の単位に変換し、合算する
+    menu_ingredients = MenuIngredient.where(menu_id: @menu.id)
+    ingredients = menu_ingredients.includes(:ingredient).map(&:ingredient)
+    @aggregated_ingredients = aggregate_ingredients(ingredients)
+  end
+
   private
 
   def menu_params

--- a/app/views/menus/custom_menus.html.erb
+++ b/app/views/menus/custom_menus.html.erb
@@ -8,8 +8,8 @@
     <%= button_to "オリジナル献立作成", new_user_menu_path(current_user.id), class: "original-menu-button", method: :get %>
 
     <div class="original_menus_list">
-      <% if @original_menus.any? %>
-        <% @original_menus.each do |menu| %>
+      <% @original_menus.each do |menu| %>
+        <%= link_to user_menu_path(current_user, menu), class: "menu-item-link" do %>
           <div class="menu-item">
             <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
             <div class="menu-item-title"><%= menu.menu_name %></div>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -1,0 +1,65 @@
+
+<div class="menu-show-container">
+  <div class="menu-detail-container">
+    <div class="menu-show-list">
+      <div class="menu-show-title">
+        <h1>献立情報</h1>
+      </div>
+
+      <div class="show-contents-title">
+        <p>　献立名　</p>
+      </div>
+
+      <div class="menu-contents">
+        <%= @menu.menu_name %>
+      </div>
+
+      <div class="show-contents-title">
+        <p>　献立内容　</p>
+      </div>
+      <div class ="menu-contents">
+        <%= @menu.menu_contents %>
+      </div>
+
+      <div class="show-contents-title">
+        <p>　作り方　</p>
+      </div>
+      <div class="menu-contents">
+        <%= simple_format(sanitize(@menu.contents)) %>
+      </div>
+
+      <div class="show-contents-title">
+        <p>　献立画像　</p>
+      </div>
+
+      <div class ="menu-contents">
+        <%= image_tag(rails_blob_path(@menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+      </div>
+    </div>
+
+    <div class="ingredient-show-container">
+      <div class ="show-contents-title">
+        <p>　食材リスト　</p>
+      </div>
+
+      <div class="ingredients-show-list">
+        <% if @aggregated_ingredients.present? %>
+          <% @aggregated_ingredients.each do |aggregated_ingredient| %>
+            <div class="ingredient-show-item">
+              <p class="material-name"><%= aggregated_ingredient.material.material_name %></p>
+              <div class="quantity-unit">
+                <p class="quantity"><%= aggregated_ingredient.quantity %></p>
+                <p class="unit"><%= aggregated_ingredient.unit.unit_name %></p>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <p class="no-ingredients">食材はありません</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+
+  <button onclick="history.back()" class="back-button">戻る</button>
+</div>


### PR DESCRIPTION
目的：
ユーザーが献立一覧ページから各献立の詳細ページへ簡単にアクセスできるようにすることが目的です。

内容：
・献立一覧ページにおいて、各献立項目をクリック可能にし、対応する詳細ページへのリンクを実装
・詳細ページのHTMLとCSSを更新し、レイアウトとスタイリングを改善
・レスポンシブデザインの考慮に基づき、ビューのスタイルをモバイルフレンドリーに調整


<img width="1137" alt="スクリーンショット 2023-11-29 11 49 36" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/c513a9a8-8742-4861-8c96-93c04c4ee22d">
<img width="947" alt="スクリーンショット 2023-11-29 11 49 42" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/2c7b8799-7e37-4841-aed2-8f3c4a40cdf8">
<img width="382" alt="スクリーンショット 2023-11-29 11 49 54" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/167d9e68-61d0-4bce-929e-84d2a6ec85d1">
<img width="346" alt="スクリーンショット 2023-11-29 11 50 02" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/5ba97a17-4b42-403b-b6f6-59308283537b">