### PR TITLE
ページネーションに対してTurboFrameの範囲設定とリンクの非同期挙動無効化を実施

### DIFF
--- a/app/views/menus/custom_menus.html.erb
+++ b/app/views/menus/custom_menus.html.erb
@@ -1,26 +1,27 @@
 <%= render 'shared/menu' %>
 
 <div class="menus-container">
-
   <h3 class="original-menu-heading">オリジナル献立</h3>
 
   <div class="menus_list">
     <%= button_to "オリジナル献立作成", new_user_menu_path(current_user.id), class: "original-menu-button", method: :get %>
 
-    <div class="original_menus_list">
-      <% @original_menus.each do |menu| %>
-        <%= link_to user_menu_path(current_user, menu), class: "menu-item-link" do %>
-          <div class="menu-item">
-            <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
-            <div class="menu-item-title"><%= menu.menu_name %></div>
-          </div>
+    <%= turbo_frame_tag 'original_menus_frame' do %>
+      <div class="original_menus_list">
+        <% @original_menus.each do |menu| %>
+          <%= link_to user_menu_path(current_user, menu), class: "menu-item-link", data: { turbo: false } do %>
+            <div class="menu-item">
+              <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+              <div class="menu-item-title"><%= menu.menu_name %></div>
+            </div>
+          <% end %>
         <% end %>
-      <% end %>
-    </div>
+      </div>
 
-    <div class="pagination-container">
-      <%= paginate @original_menus %>
-    </div>
+      <div class="pagination-container">
+        <%= paginate @original_menus, data: { turbo_frame: 'original_menus_frame' } %>
+      </div>
+    <% end %>
   </div>
 
   <%= button_to "戻る", root_path, class: "back-button", method: :get %>

--- a/app/views/menus/sample_menus.html.erb
+++ b/app/views/menus/sample_menus.html.erb
@@ -1,25 +1,28 @@
 <%= render 'shared/menu' %>
 
 <div class="menus-container">
-
   <h3 class="menu-list-heading">サンプル献立</h3>
 
-  <div class ="menus_list">
+  <div class="menus_list">
     <% if @default_menus.any? %>
-      <div class ="sample-menus-list">
-        <% @default_menus.each do |menu| %>
-          <div class="menu-item">
-            <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
-            <div class="menu-item-title"><%= menu.menu_name %></div>
-          </div>
-        <% end %>
+      <%= turbo_frame_tag 'default_menus_frame' do %>
+        <div class="sample-menus-list">
+          <% @default_menus.each do |menu| %>
+            <%= link_to user_menu_path(current_user, menu), class: "menu-item-link", data: { turbo: false } do %>
+              <div class="menu-item">
+                <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+                <div class="menu-item-title"><%= menu.menu_name %></div>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+
+        <div class="pagination-container">
+          <%= paginate @default_menus, data: { turbo_frame: 'default_menus_frame' } %>
+        </div>
       <% end %>
-    </div>
-
-    <div class="pagination-container">
-      <%= paginate @default_menus %>
-    </div>
-
-    <%= button_to "戻る", root_path, class: "back-button", method: :get %>
+    <% end %>
   </div>
+
+  <%= button_to "戻る", root_path, class: "back-button", method: :get %>
 </div>


### PR DESCRIPTION
目的：
ユーザーインターフェイスの改善とページ遷移の効率化を目的としています。

内容：
・サンプル献立およびオリジナル献立のページネーションにTurbo Frameを適用
・メニュー項目へのリンクに data-turbo="false" 属性を追加