### PR TITLE
設定値を外部化してマジックナンバーを削減

### DIFF
--- a/app/views/menus/custom_menus.html.erb
+++ b/app/views/menus/custom_menus.html.erb
@@ -18,8 +18,8 @@
         <% end %>
       </div>
 
-      <%= render 'shared/pagination', total_menus_count: @total_menus_count, items_per_page: @items_per_page, current_page: @current_page, 
-      first_page: @first_page, pagination_path: ->(page) { user_custom_menus_path(page: page) } %>
+      <%= render 'shared/pagination', total_menus_count: @total_menus_count, items_per_page: @settings.dig('pagination', 'items_per_page'),
+      first_page: @settings.dig('pagination', 'first_page'), pagination_path: ->(page) { user_custom_menus_path(page: page) } %>
 
     <% end %>
   </div>

--- a/app/views/menus/sample_menus.html.erb
+++ b/app/views/menus/sample_menus.html.erb
@@ -17,8 +17,8 @@
           <% end %>
         </div>
 
-        <%= render 'shared/pagination', total_menus_count: @total_menus_count, items_per_page: @items_per_page,
-        first_page: @first_page, pagination_path: ->(page) { sample_menus_path(page: page) } %>
+        <%= render 'shared/pagination', total_menus_count: @total_menus_count, items_per_page: @settings.dig('pagination', 'items_per_page'),
+        first_page: @settings.dig('pagination', 'first_page'), pagination_path: ->(page) { sample_menus_path(page: page) } %>
 
       <% end %>
     <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,4 @@
+
+pagination:
+  items_per_page: 10
+  first_page: 1


### PR DESCRIPTION
目的：
コード内のマジックナンバーを削減し、コードの可読性と保守性を向上させることを目的としています。

内容：
・config/settings.yml に、ページネーションの items_per_page と first_page の設定を追加
・menuコントローラーとビューで、これらの設定値を settings.yml から読み込むように変更

備考：
具体的にはページネーションとフォーム関連の設定値を settings.yml に外部化し、これらの値をコード内で直接参照する代わりに設定ファイルから取得するように変更しています。