### PR TITLE
MenusControllerの可読性向上のためのリファクタリング

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,3 +2,6 @@
 pagination:
   items_per_page: 10
   first_page: 1
+
+ingredient:
+  no_quantity_unit_id: 17


### PR DESCRIPTION
目的：
MenusControllerにおける複数の処理が複雑化しており、コードの可読性と保守性に影響を与えていました。このリファクタリングの主な目的は、コードの明確化と将来的な拡張性の向上にあります。

内容：
・複数の処理を行うメソッドを個別のメソッドに分割
・マジックナンバーの除去
・一部コードの構造を見直し（例：「unless params[:menu].present?」を「if params[:menu].blank?」に変更）