### PR TITLE
メニュー編集機能の追加と更新アクションの実装

### DIFF
--- a/app/assets/stylesheets/menu/menu_list.scss
+++ b/app/assets/stylesheets/menu/menu_list.scss
@@ -93,7 +93,7 @@
   }
 
   .back-button {
-    @include back-button;
+    @include button;
   }
 }
 

--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -7,7 +7,7 @@
     @include contents-title;
   }
 
-  .menu-registration-back-button {
+  .menu-form-back-button {
     width: 80%;
     margin: 0 auto;
     @media screen and (max-width: 1100px) {
@@ -29,7 +29,7 @@
     }
   }
 
-  .menu-registration-container{
+  .menu-form-container{
     text-align: center;
     width: 60%;
     @media screen and (max-width: 500px) {
@@ -41,7 +41,7 @@
       color: rgb(250, 43, 43);
     }
 
-    .menu-registration-input{
+    .menu-form-input{
       .menu-error{
         font-size: 15px;
         color: rgb(250, 43, 43);
@@ -63,8 +63,8 @@
 
     }
 
-    .name-registration-field input,
-    .menu-registration-field input,
+    .name-form-field input,
+    .menu-contents-field input,
     textarea{
       width: 100%;
       padding-top: 13px;
@@ -83,7 +83,7 @@
       opacity: 0.8;
     }
 
-    .image-registration-field input{
+    .image-field input{
       width: 90%;
       padding: 10px 4%;
       font-size: 13px;
@@ -91,7 +91,7 @@
       margin-right: 13px;
     }
 
-    .menu-registration-actions {
+    .menu-form-actions {
       width: 80%;
       margin: 0 auto;
       margin-top: 40px;
@@ -100,7 +100,7 @@
       }
     }
 
-    .menu-registration-actions input{
+    .menu-form-actions input{
       padding: 10px 40%;
       font-size: 15px;
       background-color: #1E9AF4;
@@ -111,9 +111,9 @@
   }
 
   // 献立画面のスタイル
-  .ingredient-registration-input{
+  .ingredient-form-input{
     width: 100%;
-    .ingredient-registration-field{
+    .ingredient-form-field{
       justify-content: space-between;
       align-items: center;
       border-radius: 5px;

--- a/app/assets/stylesheets/menu/menu_show.scss
+++ b/app/assets/stylesheets/menu/menu_show.scss
@@ -69,8 +69,36 @@
     }
   }
 
-  .back-button{
-    @include back-button;
-    width: 45%;
+  .menu-button-container {
+    width: 100%;
+    .select-button {
+      @include button;
+      width: 45%;
+      background-color: #555;
+      margin-bottom: 10px;
+      height: 80px;
+
+      &:hover {
+        background-color: lighten(#7d7d7d, 10%);
+      }
+    }
+
+    .edit-button {
+      @include button;
+      width: 45%;
+      background-color: #777;
+      margin-top: 30px;
+      margin-bottom: 10px;
+
+      &:hover {
+        background-color: lighten(#7d7d7d, 10%);
+      }
+    }
+
+    .back-button {
+      @include button;
+      width: 45%;
+      margin-top: 10px;
+    }
   }
 }

--- a/app/assets/stylesheets/shared/_styles.scss
+++ b/app/assets/stylesheets/shared/_styles.scss
@@ -91,7 +91,7 @@
   }
 }
 
-@mixin back-button {
+@mixin button {
   display: block;
   margin: 50px auto;
   padding: 15px 0;
@@ -104,6 +104,7 @@
   border-radius: 25px;
   cursor: pointer;
   transition: background-color 0.3s ease;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
   @media screen and (max-width: 800px) {
     width: 80%;
   }

--- a/app/javascript/addForm.js
+++ b/app/javascript/addForm.js
@@ -22,22 +22,10 @@ if (count_up_bottom) {
   });
 }
 
-document.addEventListener("DOMContentLoaded", function() {
-  document.addEventListener("click", function(event) {
-    if (!event.target.classList.contains("form-count-down")) return;
-
-    event.preventDefault();
-
-    // クリックされた要素の最も近い ".custom-ingredient-fields" 要素を取得
-    var container = event.target.closest(".custom-ingredient-fields");
-    if (!container) return;
-
-    container.remove(); // 該当する要素を削除
-    formCount_view--; // 表示中のフォーム数をデクリメント
-    formCount_back--; // バックエンド用のフォーム数をデクリメント
-    updateFormNumbers(); // フォーム番号を更新
-    updateMaxCountText(formCount_view, maxFormCount_view) // 最大フォーム数テキストを更新
-  });
+document.addEventListener("click", function(event) {
+  if (event.target.classList.contains("form-count-down")) {
+      handleCountDownClick(event);
+  }
 });
 
 
@@ -159,7 +147,7 @@ function createNewForms(defaultMaxCount, Data){
 }
 
 function updateForm(){
-  var ingredientsDate = document.getElementById('ingredientsDate');
+  var ingredientsDate = document.getElementById('ingredients-date');
   // data-ingredients 属性の値を取得
   var dataAttr = ingredientsDate.getAttribute('data-ingredients');
   // JSON文字列をオブジェクトに変換
@@ -192,4 +180,54 @@ function updateForm(){
     const maxCount = 5
     createNewForms(maxCount, parsedIngredients)
   }
+}
+
+// 食材セット時にunitフォームへ専用の単位を設定する（addForm.jsでも使用しています。）
+function handleIngredientNameChange(selectElement, value) {
+  const material_name = value;
+  const userId = document.querySelector('.menu-form-container').getAttribute('data-user-id');
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const url = `/users/${userId}/menus/units`;
+  fetch(url, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': token
+    },
+    body: JSON.stringify({ material_name: material_name })
+  })
+  .then(response => response.json())
+  .then(data => {
+
+    while (selectElement.firstChild) {
+      selectElement.removeChild(selectElement.firstChild);
+    }
+
+    data.forEach(item => {
+      const option = document.createElement('option');
+      option.value = item.id;
+      option.textContent = item.name;
+      selectElement.appendChild(option);
+      selectElement.style.pointerEvents = 'auto';
+      selectElement.removeAttribute('tabindex');
+    });
+  });
+}
+
+function handleCountDownClick(event) {
+  event.preventDefault();
+
+  console.log("処理きました");
+
+  // クリックされた要素の最も近い ".custom-ingredient-fields" 要素を取得
+  var container = event.target.closest(".custom-ingredient-fields");
+  if (!container) return;
+
+  container.remove(); // 該当する要素を削除
+  formCount_view--; // 表示中のフォーム数をデクリメント
+  formCount_back--; // バックエンド用のフォーム数をデクリメント
+  updateFormNumbers(); // フォーム番号を更新
+  updateMaxCountText(formCount_view, maxFormCount_view) // 最大フォーム数テキストを更新
 }

--- a/app/javascript/ingredient_dropdown.js
+++ b/app/javascript/ingredient_dropdown.js
@@ -208,7 +208,7 @@ function handleIngredientUnitChange(clickedElement) {
 // 食材セット時にunitフォームへ専用の単位を設定する（addForm.jsでも使用しています。）
 function handleIngredientNameChange(selectElement, value) {
   const material_name = value;
-  const userId = document.querySelector('.menu-registration-container').getAttribute('data-user-id');
+  const userId = document.querySelector('.menu-form-container').getAttribute('data-user-id');
   const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
   const url = `/users/${userId}/menus/units`;

--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -15,16 +15,16 @@ document.addEventListener('submit', function(event) {
   let menu_contents = document.getElementById("menu_contents");
   let contents = document.getElementById("contents");
   let errorMessage_name = document.getElementById("menu-error_name");
-  let errorMessage_contents = document.getElementById("menu-error-contents-1");
-  let errorMessage_contents_2 = document.getElementById("menu-error-contents-2");
-  let inputName = document.querySelector(".name-registration-field input");
-  let inputContent = document.querySelector(".menu-registration-field input");
+  let errorMessage_menu_contents = document.getElementById("menu-error-menu-contents");
+  let errorMessage_contents = document.getElementById("menu-error-contents");
+  let inputName = document.querySelector(".name-form-field input");
+  let inputContent = document.querySelector(".menu-contents-field input");
   let inputText = document.querySelector("textarea");
 
   // menuモデルのバリデーション
   validateAndHighlightInput(menu_name, errorMessage_name, inputName, event)
-  validateAndHighlightInput(menu_contents, errorMessage_contents, inputContent, event)
-  validateAndHighlightInput(contents, errorMessage_contents_2, inputText, event)
+  validateAndHighlightInput(menu_contents, errorMessage_menu_contents, inputContent, event)
+  validateAndHighlightInput(contents, errorMessage_contents, inputText, event)
 
   // ingredientモデルのバリデーション
   for (let i = minForm; i < maxForm; i++) {

--- a/app/views/menus/_form_fields.html.erb
+++ b/app/views/menus/_form_fields.html.erb
@@ -1,0 +1,18 @@
+<div id="menu-error_name" class="menu-error"></div>
+<div class="name-form-field">
+  <%= f.text_field :menu_name, id: "menu_name", autofocus: true, autocomplete: "menu_name", placeholder: "献立名(最大20字)", maxlength: 20 %>
+</div>
+
+<div id="menu-error-menu-contents" class="menu-error"></div>
+<div class="menu-contents-field">
+  <%= f.text_field :menu_contents, id: "menu_contents", autofocus: true, autocomplete: "menu_contents", placeholder: "献立内容(最大20字)", maxlength: 20 %>
+</div>
+
+<div id="menu-error-contents" class="menu-error"></div>
+<div class="content-field">
+  <%= f.text_area :contents, id: "contents", autofocus: true, autocomplete: "contents", placeholder: "作り方(最大700字)", maxlength: 700 %>
+</div>
+
+<div class="image-field">
+  <%= f.file_field :image, autofocus: true, autocomplete: "image", placeholder: "献立の写真", id: "menu_image" %>
+</div>

--- a/app/views/menus/_image_preview.html.erb
+++ b/app/views/menus/_image_preview.html.erb
@@ -1,0 +1,3 @@
+<div class="image-preview-container">
+  <img id="image-preview" src="<%= image_data_url if image_data_url.present? %>" width="300" height="200" alt="uploaded image preview" style="<%= 'display: none;' unless image_data_url.present? %>" />
+</div>

--- a/app/views/menus/_ingredient_selector.html.erb
+++ b/app/views/menus/_ingredient_selector.html.erb
@@ -1,0 +1,25 @@
+<div id="ingredient-select" class="ingredient-select">
+  <div class="search-header">
+    <span class="close-button"><span class="close-icon">×</span></span>
+    <input type="text" id="ingredientSearchInput" class="SearchInput" placeholder="食材名を検索" />
+  </div>
+  <p class="search-results-title">検索結果</p>
+  <div id="searchResultsContainer" class="searchContainer"></div>
+  <p class="drop-down-title">食材一覧</p>
+  <div class="scrollable-section">
+    <% materials_by_category.each_with_index do |(category, materials), index| %>
+      <div class="ingredient-category">
+        <p id="categoryElement-<%= index %>" class="categoryElement"><%= category %></p>
+
+        <ul id="ingredients-list-<%= index %>" style="display: none;">
+          <% materials.each do |material| %>
+            <% if material.material_name %>
+              <li data-value="<%= material.id %>" data-hiragana="<%= material.hiragana %>" data-material-name="<%= material.material_name %>">
+                <%= material.material_name %>
+            <% end %>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/menus/confirm.html.erb
+++ b/app/views/menus/confirm.html.erb
@@ -43,13 +43,6 @@
           <% end %>
         </div>
 
-        <% if @menu.persisted? %>
-          <p>データあり</p>
-          <%= f.hidden_field :id, value: @menu.id %>
-        <% else %>
-          <p>なし</p>
-        <% end %>
-
       </div>
 
       <div class="ingredient-confirm-container">
@@ -91,42 +84,22 @@
 
     <div class="button-confirm-container">
       <div class="menu-edit-button">
-        <% if @menu.new_record? %>
-          <%= form_with model: @menu, url: new_user_menu_path(current_user), method: :post, local: true do |f| %>
-            <%= f.hidden_field :menu_name, value: @menu.menu_name %>
-            <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
-            <%= f.hidden_field :contents, value: @menu.contents %>
-            <%= f.hidden_field :encoded_image, value: @encoded_image %>
-            <%= f.hidden_field :filename, value: @menu.image.filename.to_s %>
-            <%= f.hidden_field :image_content_type, value: @menu.image.content_type %>
+        <%= form_with model: @menu, url: new_user_menu_path(current_user), method: :post, local: true do |f| %>
+          <%= f.hidden_field :menu_name, value: @menu.menu_name %>
+          <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
+          <%= f.hidden_field :contents, value: @menu.contents %>
+          <%= f.hidden_field :encoded_image, value: @encoded_image %>
+          <%= f.hidden_field :filename, value: @menu.image.filename.to_s %>
+          <%= f.hidden_field :image_content_type, value: @menu.image.content_type %>
 
-            <% @menu.ingredients.each_with_index do |ingredient, index| %>
-              <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>
-              <%= f.hidden_field "ingredients_attributes[#{index}][material_id]", value: ingredient.material.id %>
-              <%= f.hidden_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity %>
-              <%= f.hidden_field "ingredients_attributes[#{index}][unit_id]", value: ingredient.unit.id %>
-            <% end %>
-
-            <%= f.submit "編集", class: "edit-button" %>
+          <% @menu.ingredients.each_with_index do |ingredient, index| %>
+            <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>
+            <%= f.hidden_field "ingredients_attributes[#{index}][material_id]", value: ingredient.material.id %>
+            <%= f.hidden_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity %>
+            <%= f.hidden_field "ingredients_attributes[#{index}][unit_id]", value: ingredient.unit.id %>
           <% end %>
-        <% else %>
-          <%= form_with url: edit_user_menu_path(current_user, @menu), method: :post, local: true do |f| %>
-            <%= f.hidden_field :menu_name, value: @menu.menu_name %>
-            <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
-            <%= f.hidden_field :contents, value: @menu.contents %>
-            <%= f.hidden_field :encoded_image, value: @encoded_image %>
-            <%= f.hidden_field :filename, value: params[:menu][:image].original_filename %>
-            <%= f.hidden_field :image_content_type, value: @menu.image.content_type %>
 
-            <% @menu.ingredients.each_with_index do |ingredient, index| %>
-              <%= f.hidden_field "ingredients[#{index}][material_name]", value: ingredient.material_name %>
-              <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
-              <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
-              <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
-            <% end %>
-
-            <%= f.submit "編集", class: "edit-button" %>
-          <% end %>
+          <%= f.submit "編集", class: "edit-button" %>
         <% end %>
       </div>
     </div>

--- a/app/views/menus/confirm.html.erb
+++ b/app/views/menus/confirm.html.erb
@@ -1,4 +1,3 @@
-
 <div class="confirm-container">
   <div class="confirm-form-container">
     <%= form_with model: [current_user, @menu], local: true do |f| %>
@@ -43,6 +42,14 @@
             <p>画像なし</p>
           <% end %>
         </div>
+
+        <% if @menu.persisted? %>
+          <p>データあり</p>
+          <%= f.hidden_field :id, value: @menu.id %>
+        <% else %>
+          <p>なし</p>
+        <% end %>
+
       </div>
 
       <div class="ingredient-confirm-container">

--- a/app/views/menus/edit.html.erb
+++ b/app/views/menus/edit.html.erb
@@ -12,16 +12,9 @@
     <div id="main-menu-error" class="menu-error-message"></div>
 
     <div class="menu-form-input">
-      <%= form_with model: @menu, url: confirm_user_menu_path(current_user.id), method: :post, id: "menu_form" do |f| %>
+      <%= form_with model: @menu, url: user_menu_path(current_user, @menu), method: :patch, id: "menu_form" do |f| %>
         <%= render 'form_fields', f: f %>
         <%= render 'image_preview', image_data_url: @image_data_url %>
-
-        <% if @image_data_url.present? %>
-          <%= f.hidden_field :encoded_image, value: @encoded_image %>
-          <%= f.hidden_field :image_content_type, value: params[:menu][:image_content_type] %>
-          <%= f.hidden_field :image_data_url, value: @image_data_url %>
-        <% end %>
-
 
         <div class ="contents-title">
           <p>２.食材リスト設定</p>
@@ -46,12 +39,12 @@
         </div>
 
         <div class="menu-form-actions", data-turbo-action="submit">
-          <%= f.submit "次へ", id: "next_step_button" %>
+          <%= f.submit "更新", id: "next_step_button" %>
         </div>
       <% end %>
 
       <div class="menu-form-back-button">
-        <%= button_to '戻る', user_custom_menus_path(current_user), class: 'back-button', id: 'back_button', method: :get %>
+        <%= button_to '戻る', user_menu_path(current_user, @menu), method: :get, class: 'back-button', id: 'back_button' %>
       </div>
 
     </div>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -60,6 +60,13 @@
     </div>
   </div>
 
+  <div class="menu-button-container">
+    <%= button_to '献立を選択', '#', method: :get, class: 'select-button', id: 'select_button' %>
 
-  <button onclick="history.back()" class="back-button">戻る</button>
+    <% if UserMenu.exists?(menu_id: @menu.id, user_id: current_user.id) %>
+      <%= button_to '編集', edit_user_menu_path(@menu), method: :get, class: 'edit-button', id: 'edit_button' %>
+    <% end %>
+
+    <%= button_to '戻る', user_custom_menus_path(current_user), method: :get, class: 'back-button', id: 'back_button' %>
+  </div>
 </div>


### PR DESCRIPTION
目的：
メニューの編集と更新機能を追加することでユーザーは既存のメニュー情報を編集し、更新を可能にすることが目的です。

内容：
・edit,updateアクションの追加
・edit.html.erbの作成とスタイル設定
・メニュー編集に関連するJavaScriptとスタイルシートの調整
・new.html.erbとedit.html.erbの共通コードをパーシャル化
・new.html.erbとedit.html.erbで共通スタイルを設定するためクラス名をより汎用的で、特定のアクション（新規登録や編集）に依存しないものに変更
