### PR TITLE
CartとCartItemモデルを追加し、関連するリレーションを設定

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,0 +1,4 @@
+class Cart < ApplicationRecord
+  belongs_to :user
+  has_many :cart_items
+end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,0 +1,4 @@
+class CartItem < ApplicationRecord
+  belongs_to :cart
+  belongs_to :menu
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -3,6 +3,7 @@ class Menu < ApplicationRecord
   has_many :users, through: :menu_users
   has_one_attached :image
   has_many :ingredients, through: :menu_ingredients, autosave: false
+  has_many :cart_items
 
   validates :menu_name, presence: true, length: { maximum: 15 }
   validates :menu_contents, presence: true, length: { maximum: 20 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
 
   has_many :menu_users
   has_many :menus, through: :menu_users
+  has_one :cart
 end

--- a/db/migrate/20231204041537_create_carts.rb
+++ b/db/migrate/20231204041537_create_carts.rb
@@ -1,0 +1,9 @@
+class CreateCarts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :carts do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231204041549_create_cart_items.rb
+++ b/db/migrate/20231204041549_create_cart_items.rb
@@ -1,0 +1,11 @@
+class CreateCartItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cart_items do |t|
+      t.references :cart, null: false, foreign_key: true
+      t.references :menu, null: false, foreign_key: true
+      t.integer :item_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_17_110904) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_04_041549) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_110904) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "cart_items", force: :cascade do |t|
+    t.bigint "cart_id", null: false
+    t.bigint "menu_id", null: false
+    t.integer "item_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cart_id"], name: "index_cart_items_on_cart_id"
+    t.index ["menu_id"], name: "index_cart_items_on_menu_id"
+  end
+
+  create_table "carts", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_carts_on_user_id"
   end
 
   create_table "categories", force: :cascade do |t|
@@ -128,4 +145,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_17_110904) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "cart_items", "carts"
+  add_foreign_key "cart_items", "menus"
+  add_foreign_key "carts", "users"
 end

--- a/test/fixtures/cart_items.yml
+++ b/test/fixtures/cart_items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  cart: one
+  menu: one
+  item_count: 1
+
+two:
+  cart: two
+  menu: two
+  item_count: 1

--- a/test/fixtures/carts.yml
+++ b/test/fixtures/carts.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+
+two:
+  user: two

--- a/test/models/cart_item_test.rb
+++ b/test/models/cart_item_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CartItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/cart_test.rb
+++ b/test/models/cart_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CartTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
買い物リスト機能の基盤となるCartモデルとCartItemモデルを追加し、これらのモデル間及びUserモデルとMenuモデルとのリレーションを設定が目的です。

内容：
・Cartモデルを追加し、Userモデルにhas_one :cartの関連付けを実施
・CartItemモデルを追加し、CartモデルとMenuモデルとの間にbelongs_toの関連付けを実施
・CartItemには、cart_id、menu_id、およびitem_count（数量）のカラムを追加
・データベースマイグレーションを実行し、関連するテーブルの構造を更新
