### PR TITLE
ユーザーのカートに献立の追加・削除機能を実装

### DIFF
--- a/app/assets/stylesheets/menu/menu_show.scss
+++ b/app/assets/stylesheets/menu/menu_show.scss
@@ -71,15 +71,75 @@
 
   .menu-button-container {
     width: 100%;
-    .select-button {
-      @include button;
-      width: 45%;
-      background-color: #555;
-      margin-bottom: 10px;
-      height: 80px;
 
-      &:hover {
-        background-color: lighten(#7d7d7d, 10%);
+    .item-selection-container{
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      .quantity-selector{
+        display: flex;
+        margin-right: 0px;
+        .quantity-input {
+          width: 3em;
+          text-align: center;
+        }
+
+        button,
+        .quantity-input {
+          border: 1px solid #ccc;
+          vertical-align: middle;
+          margin: 0;
+        }
+
+        button {
+          background-color: #fff;
+          line-height: 1;
+          border-radius: 0;
+          padding: 0 15px;
+          cursor: pointer;
+          &:first-child {
+            border-right: none;
+          }
+          &:last-child {
+            border-left: none;
+          }
+          &:hover {
+            background-color: #969696;
+          }
+        }
+
+        .decrease-quantity{
+          font-size: 20px
+        }
+
+        .increase-quantity{
+          font-size: 20px
+        }
+      }
+
+      .select-button {
+        @include button;
+        border-radius: 0%;
+        width: 15%;
+        background-color: #555;
+        margin-bottom: 10px;
+        height: 60px;
+        margin: 0;
+        @media screen and (max-width: 800px) {
+          width: 50%;
+        }
+
+        &:hover {
+          background-color: lighten(#7d7d7d, 10%);
+        }
+      }
+
+      .quantity-input {
+        width: 100px;
+        height: 50px;
+        font-size: 20px;
+        padding: 5px 10px;
       }
     }
 

--- a/app/assets/stylesheets/shared/_styles.scss
+++ b/app/assets/stylesheets/shared/_styles.scss
@@ -109,3 +109,42 @@
     width: 80%;
   }
 }
+
+
+@mixin menus_list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  padding-top: 50px;
+  gap: 10px;
+  align-items: stretch;
+  justify-content: center;
+}
+
+@mixin menu-item {
+  width: 250px;
+  height: 250px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: #f8f8f8;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border-radius: 8px;
+  border-radius: 20px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  cursor: pointer;
+}
+
+
+@mixin menu-item-title {
+  margin-top: 10px;
+  color: black;
+  text-decoration: none;
+}
+
+@mixin rounded-image {
+  border-radius: 20px;
+}

--- a/app/assets/stylesheets/user-index.scss
+++ b/app/assets/stylesheets/user-index.scss
@@ -8,7 +8,7 @@
   .menu-heading {
     display: block;
     margin-top: 10px;
-    margin-bottom: 50px;
+    margin-bottom: 30px;
     font-size: 30px;
     position: relative;
     display: inline-block;
@@ -36,7 +36,7 @@
     .menu-item{
       position: relative;
       width: 250px;
-      height: 270px;
+      height: 300px;
       display: flex;
       flex-direction: column;
       justify-content: center;
@@ -73,6 +73,37 @@
         align-items: center;
         justify-content: center;
         padding: 5px;
+      }
+    }
+
+    .menu-item-count {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-top: 10px;
+
+      .decrement-button,
+      .increment-button {
+        font-size: 20px;
+        background: none;
+        border: none;
+        cursor: pointer;
+        width: 40px;
+        height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        &:hover {
+          background-color: #e6e6e6;
+        }
+      }
+
+      .menu-item-quantity {
+        font-size: 16px;
+        text-align: center;
+        width: 40px;
+        padding: 5px 10px;
       }
     }
   }

--- a/app/assets/stylesheets/user-index.scss
+++ b/app/assets/stylesheets/user-index.scss
@@ -1,42 +1,128 @@
-.button-set-container {
-  display: block;
-  position: fixed;
-  bottom: 20px;
-  width: 100%;
+@import 'shared/styles';
+
+.menu-index-container{
   text-align: center;
+  width: 100%;
+  justify-content: center;
 
-  .button-style {
+  .menu-heading {
+    display: block;
     margin-top: 10px;
-    padding: 10px 0;
-    width: 30%;
-    font-size: 15px;
-    color: white;
-    border-radius: 20px;
+    margin-bottom: 50px;
+    font-size: 30px;
+    position: relative;
     display: inline-block;
-    box-sizing: border-box;
-    text-align: center;
-    cursor: pointer;
-  }
-
-  /* ボタンの背景色クラス */
-  .bg-custom-menu {
-    background-color: #555;
-  }
-
-  .bg-standard-menu {
-    background-color: #777;
-  }
-
-  .bg-shopping-list {
-    background-color: #333;
-    height: 60px;
-    margin-top: 20px;
-    font-size: 25px;
-  }
-
-  @media screen and (max-width: 800px) {
-    .button-style {
-      width: 80%;
+    padding-bottom: 5px;
+    @media screen and (max-width: 460px) {
+      display: inline-block;
+      font-size: 20px;
     }
+  }
+
+  .menu-heading h3 {
+    margin-bottom: 0;
+    padding-bottom: 5px;
+    line-height: 1.2;
+  }
+
+  .menus_list{
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    gap: 10px;
+    align-items: stretch;
+    justify-content: center;
+
+    .menu-item{
+      position: relative;
+      width: 250px;
+      height: 270px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      background-color: #f8f8f8;
+      border: 1px solid #ddd;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      border-radius: 8px;
+      border-radius: 20px;
+      margin-right: 10px;
+      margin-bottom: 10px;
+
+      .rounded-image {
+        border-radius: 20px;
+      }
+
+      .menu-item-title {
+        margin-top: 10px;
+        color: black;
+        text-decoration: none;
+      }
+
+      .delete-button {
+        position: absolute;
+        top: -8px;
+        left: -8px;
+        border-radius: 50%;
+        cursor: pointer;
+        font-size: 30px;
+        color: rgba(0, 0, 0, 0.8);
+        width: 35px;
+        height: 35px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 5px;
+      }
+    }
+  }
+
+
+  .button-set-container {
+    display: block;
+    bottom: 20px;
+    width: 100%;
+    text-align: center;
+    margin-top: 20px;
+    margin-bottom: 25px;
+
+    .button-style {
+      margin-top: 10px;
+      padding: 10px 0;
+      width: 30%;
+      font-size: 15px;
+      color: white;
+      border-radius: 20px;
+      display: inline-block;
+      box-sizing: border-box;
+      text-align: center;
+      cursor: pointer;
+    }
+
+    /* ボタンの背景色クラス */
+    .bg-custom-menu {
+      background-color: #555;
+    }
+
+    .bg-standard-menu {
+      background-color: #777;
+    }
+
+    .bg-shopping-list {
+      background-color: #333;
+      height: 60px;
+      margin-top: 20px;
+      font-size: 25px;
+    }
+
+    @media screen and (max-width: 800px) {
+      .button-style {
+        width: 80%;
+      }
+    }
+  }
+
+  .empty-cart-message{
+    margin-bottom: 60px;
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
   include Devise::Controllers::Helpers
+  before_action :load_settings
+  before_action :set_cart_items
 
   private
 
@@ -8,5 +10,15 @@ class ApplicationController < ActionController::Base
     unless current_user
       redirect_to new_user_custom_session_path
     end
+  end
+
+  # 各アクション内で必要な設定値を @settings 変数に格納
+  def load_settings
+    @settings = YAML.load_file(Rails.root.join('config', 'settings.yml'))
+  end
+
+  def set_cart_items
+    cart = current_user.cart
+    @cart_items = cart.cart_items.includes(:menu) if cart
   end
 end

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -27,4 +27,18 @@ class CartItemsController < ApplicationController
 
     redirect_back(fallback_location: root_path)
   end
+
+
+  def increment
+    cart_item = CartItem.find_by(id: params[:id])
+    cart_item.increment!(:item_count)
+    redirect_back(fallback_location: root_path)
+  end
+
+
+  def decrement
+    cart_item = CartItem.find_by(id: params[:id])
+    cart_item.decrement!(:item_count) if cart_item.item_count > 1
+    redirect_back(fallback_location: root_path)
+  end
 end

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,0 +1,30 @@
+class CartItemsController < ApplicationController
+
+  def create
+    # 現在のユーザーのカートを取得または新規作成
+    cart = current_user.cart || current_user.create_cart
+
+    # カート内の同じmenu_idのアイテムを検索
+    cart_item = cart.cart_items.find_by(menu_id: params[:menu_id])
+
+    if cart_item
+      # 同じmenu_idのアイテムが存在する場合、数量を1増やす
+      cart_item.increment!(:item_count)
+    else
+      # 新しいカートアイテムの作成、数量はデフォルトで1とする
+      item_count = @settings.dig('defaults', 'item_count')
+      cart.cart_items.create(menu_id: params[:menu_id], item_count: params[:item_count])
+    end
+
+    flash[:notice] = "献立を選択しました。"
+    redirect_to root_path
+  end
+
+
+  def destroy
+    cart_item = CartItem.find(params[:id])
+    cart_item.destroy
+
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,5 +1,4 @@
 class MenusController < ApplicationController
-  before_action :load_settings
 
   def custom_menus
     # 現在ログインしているユーザーのIDに関連付けられたすべてのメニューIDを取得
@@ -347,11 +346,6 @@ class MenusController < ApplicationController
     end
 
     total_quantity
-  end
-
-  # 各アクション内で必要な設定値を @settings 変数に格納
-  def load_settings
-    @settings = YAML.load_file(Rails.root.join('config', 'settings.yml'))
   end
 
   def paginate(query)

--- a/app/helpers/cart_items_helper.rb
+++ b/app/helpers/cart_items_helper.rb
@@ -1,0 +1,2 @@
+module CartItemsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,3 +4,4 @@ import "controllers"
 import jquery from "jquery"
 window.$ = jquery
 import "./nav_menu";
+import "./quantity_selector";

--- a/app/javascript/quantity_selector.js
+++ b/app/javascript/quantity_selector.js
@@ -1,0 +1,17 @@
+
+document.addEventListener('DOMContentLoaded', function() {
+  let container = document.querySelector('.quantity-selector');
+
+  container.addEventListener('click', function(e) {
+    let button = e.target;
+    let input = document.querySelector('.quantity-input');
+    let currentValue = parseInt(input.value) || 0;
+
+    if (button.dataset.action === 'increase') {
+      input.value = currentValue + 1;
+    } else if (button.dataset.action === 'decrease') {
+      let newValue = currentValue - 1;
+      input.value = newValue >= parseInt(input.min) ? newValue : currentValue;
+    }
+  });
+});

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -61,12 +61,28 @@
   </div>
 
   <div class="menu-button-container">
-    <%= button_to '献立を選択', '#', method: :get, class: 'select-button', id: 'select_button' %>
+    <%= form_with url: cart_items_path, method: :post do |form| %>
+      <%= form.hidden_field :menu_id, value: @menu.id %>
+
+      <div class="item-selection-container">
+        <div class="quantity-selector">
+          <%= button_tag '▲', type: 'button', class: 'increase-quantity', 'data-action': 'increase' %>
+          <%= form.number_field :item_count, value: 1, min: 1, class: 'quantity-input', 'aria-label': "Item count" %>
+          <%= button_tag '▼', type: 'button', class: 'decrease-quantity', 'data-action': 'decrease' %>
+        </div>
+
+        <%= form.submit '選択', class: 'select-button', id: 'select_button' %>
+      </div>
+    <% end %>
+
+
+
 
     <% if UserMenu.exists?(menu_id: @menu.id, user_id: current_user.id) %>
       <%= button_to '編集', edit_user_menu_path(@menu), method: :get, class: 'edit-button', id: 'edit_button' %>
+      <%= button_to '戻る', user_custom_menus_path(current_user), method: :get, class: 'back-button', id: 'back_button' %>
+    <% else %>
+      <%= button_to '戻る', sample_menus_path(current_user), method: :get, class: 'back-button', id: 'back_button' %>
     <% end %>
-
-    <%= button_to '戻る', user_custom_menus_path(current_user), method: :get, class: 'back-button', id: 'back_button' %>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,37 @@
 <%= render 'shared/menu' %>
 
-<div class="button-set-container">
-  <%= button_to "オリジナル献立リスト", user_custom_menus_path(current_user), class: "button-style bg-custom-menu", method: :get %>
-  <%= button_to "サンプル献立リスト", sample_menus_path, class: "button-style bg-standard-menu", method: :get %>
-  <%= button_to "買い出しに行く", root_path, class: "button-style bg-shopping-list", method: :get %>
+<div class="menu-index-container">
+
+  <div class="menu-heading">
+    <h3>選択された献立</h3>
+  </div>
+
+  <% if @cart_items.present? %>
+    <div class="menus_list">
+      <% @cart_items.each do |cart_item| %>
+
+        <div class="menu-item">
+          <div class="delete-button">
+            <%= button_to '✖️', cart_item_path(cart_item), method: :delete, class: "delete-button" %>
+          </div>
+
+          <%= image_tag(rails_blob_path(cart_item.menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+          <div class="menu-item-title"><%= cart_item.menu.menu_name %></div>
+
+          <div class="menu-item-count">
+            <div class="menu-item-quantity">数量: <%= cart_item.item_count %></div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="empty-cart-message">カートに献立がありません。</p>
+  <% end %>
+
+
+  <div class="button-set-container">
+    <%= button_to "オリジナル献立リスト", user_custom_menus_path(current_user), class: "button-style bg-custom-menu", method: :get %>
+    <%= button_to "サンプル献立リスト", sample_menus_path, class: "button-style bg-standard-menu", method: :get %>
+    <%= button_to "買い出しに行く", root_path, class: "button-style bg-shopping-list", method: :get %>
+  </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,7 +9,6 @@
   <% if @cart_items.present? %>
     <div class="menus_list">
       <% @cart_items.each do |cart_item| %>
-
         <div class="menu-item">
           <div class="delete-button">
             <%= button_to '✖️', cart_item_path(cart_item), method: :delete, class: "delete-button" %>
@@ -19,7 +18,11 @@
           <div class="menu-item-title"><%= cart_item.menu.menu_name %></div>
 
           <div class="menu-item-count">
-            <div class="menu-item-quantity">数量: <%= cart_item.item_count %></div>
+            <%= button_to '▲', cart_item_increment_path(cart_item), method: :post, data: { turbo_frame: "menu_item_quantity_#{cart_item.id}" }, class: "increment-button" %>
+            <%= turbo_frame_tag "menu_item_quantity_#{cart_item.id}" do %>
+              <div class="menu-item-quantity"><%= cart_item.item_count %></div>
+            <% end %>
+            <%= button_to '▼', cart_item_decrement_path(cart_item), method: :post, data: { turbo_frame: "menu_item_quantity_#{cart_item.id}" }, class: "decrement-button" %>
           </div>
         </div>
       <% end %>
@@ -27,6 +30,8 @@
   <% else %>
     <p class="empty-cart-message">カートに献立がありません。</p>
   <% end %>
+
+
 
 
   <div class="button-set-container">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,8 @@ Rails.application.routes.draw do
   get 'users/:user_id/custom_menus', to: 'menus#custom_menus', as: :user_custom_menus
   # 標準献立用のルーティング
   get 'sample_menus', to: 'menus#sample_menus', as: :sample_menus
-
+  # CartItem#createへのルーティング
+  resources :cart_items, only: [:create, :destroy]
 
   devise_for :users
   devise_scope :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,20 @@ Rails.application.routes.draw do
   get 'users/:id/my_page', to: 'users#my_page', as: :user_my_page
   post '/users/:user_id/menus/confirm', to: 'menus#confirm', as: :confirm_user_menu
   post 'users/:user_id/menus/units', to: 'menus#units'
+
   # ユーザーが作成した献立用のルーティング
   get 'users/:user_id/custom_menus', to: 'menus#custom_menus', as: :user_custom_menus
+
   # 標準献立用のルーティング
   get 'sample_menus', to: 'menus#sample_menus', as: :sample_menus
+
   # CartItem#createへのルーティング
   resources :cart_items, only: [:create, :destroy]
+
+  # カートアイテムの数量を増やす
+  post '/cart_items/:id/increment', to: 'cart_items#increment', as: 'cart_item_increment'
+  # カートアイテムの数量を減らす
+  post '/cart_items/:id/decrement', to: 'cart_items#decrement', as: 'cart_item_decrement'
 
   devise_for :users
   devise_scope :user do

--- a/test/controllers/cart_items_controller_test.rb
+++ b/test/controllers/cart_items_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CartItemsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
ユーザーが献立を追加し、不要になった献立を削除できる機能を実装することが目的です。

内容：
・CartsController の create アクションを更新して、献立の数量を指定して追加できるように実装
・CartsController に destroy アクションを追加して、ホーム画面の献立を削除できるように実装
・ホーム画面で献立ごとに削除ボタンを追加し、選択を取り消しができるよう実装
・献立を追加時に数量をボタンで増減できるようJavaScriptを実装

ホーム画面
<img width="1423" alt="スクリーンショット 2023-12-05 18 55 37" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/42affb11-1e83-4987-b3f5-7566622c1adb">

追加画面
<img width="958" alt="スクリーンショット 2023-12-05 18 57 09" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/fea7c636-7fa4-4527-9ba6-f9ab2161e646">