### PR TITLE
食材の数量を小数で正確に保存するためのDBスキーマ変更

### DIFF
--- a/app/assets/stylesheets/menu/menu_confirm.scss
+++ b/app/assets/stylesheets/menu/menu_confirm.scss
@@ -24,7 +24,7 @@
       }
 
       .ingredients-list {
-        width: 50%;
+        width: 60%;
         padding-bottom: 30px;
         @media screen and (max-width: 1400px) {
           width: 95%;

--- a/app/assets/stylesheets/menu/menu_show.scss
+++ b/app/assets/stylesheets/menu/menu_show.scss
@@ -26,8 +26,13 @@
         width: 100%;
       }
 
+      .show-contents-title{
+        @include contents-title;
+        margin-bottom: 30px;
+      }
+
       .ingredients-show-list {
-        width: 50%;
+        width: 60%;
         padding-bottom: 30px;
         @media screen and (max-width: 1400px) {
           width: 95%;
@@ -76,6 +81,8 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      margin-top: 30px;
+      margin-bottom: 30px;
 
       .quantity-selector{
         display: flex;
@@ -91,7 +98,7 @@
         border-radius: 0%;
         width: 15%;
         background-color: #555;
-        margin-bottom: 10px;
+        margin-bottom: 30px;
         height: 60px;
         margin: 0;
         @media screen and (max-width: 800px) {
@@ -115,7 +122,6 @@
       @include button;
       width: 45%;
       background-color: #777;
-      margin-top: 30px;
       margin-bottom: 10px;
 
       &:hover {

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -320,7 +320,7 @@ class MenusController < ApplicationController
 
   def handle_general_error
     flash[:error] = "登録中に予期せぬエラーが発生しました。"
-    redirect_to user_menus_path
+    redirect_to root_path
   end
 
   #食材データを受け取り、それをmaterial_idに基づいてグループ化し、各グループの食材を集約する

--- a/app/helpers/menus_helper.rb
+++ b/app/helpers/menus_helper.rb
@@ -1,2 +1,10 @@
 module MenusHelper
+
+  # display_quantity メソッドは、与えられた quantity（数量）が小数点以下が0である場合（つまり実質的に整数である場合）に整数として表示するためのメソッドです。
+  # これにより、ユーザーインターフェイス上での数値の表示が、必要に応じて整数または小数として適切に行われます。
+  # 例えば、1.0は1として、1.5は1.5のままとして表示されます。
+  def display_quantity(quantity)
+    quantity.to_f == quantity.to_i ? quantity.to_i : quantity
+  end
+
 end

--- a/app/javascript/addForm.js
+++ b/app/javascript/addForm.js
@@ -58,7 +58,7 @@ function createNewForm() {
         <span class="form-number">${paddedNewFormCount}</span>
         <input id="ingredient_name[${newFormCount_back}]" class="ingredient-name" placeholder="食材名を選択" type="text" name="menu[ingredients][${newFormCount_back}][material_name]" readonly>
         <input type="hidden" id="ingredient_id[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][material_id]", class="hidden-ingredient-id">
-        <input type="text" id="ingredient_quantity[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][quantity]" autocomplete="quantity" placeholder="数量" maxlength="4" oninput="this.value = this.value.replace(/[^0-9.]/g, '')" class="ingredient-quantity">
+        <input type="number" id="ingredient_quantity[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][quantity]" autocomplete="quantity" placeholder="数量" maxlength="4" step="0.1" class="ingredient-quantity">
         <select id="menu_ingredients_unit[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][unit_id]" class="ingredient-unit" tabindex="-1">
         </select>
       </div>`;
@@ -126,11 +126,15 @@ function createNewForms(defaultMaxCount, Data){
     }
 
     if (ingredientIdField) ingredientIdField.value = currentData.material_id || '';
-    if (ingredientQuantityField) ingredientQuantityField.value = currentData.quantity || '';
+
+    if (ingredientQuantityField) {
+      // formatQuantity関数を使用して数量を整形してから設定
+      ingredientQuantityField.value = formatQuantity(currentData.quantity) || '';
+    }
 
     var ingredientUnitSelect = currentForm.querySelector(`#menu_ingredients_unit\\[${i}\\]`);
     if (ingredientUnitSelect) {
-      // 単位のセットアップ（ingredient_dropdown.jsにコードあります。）
+      // 単位のセットアップ
       handleIngredientNameChange(ingredientUnitSelect, currentData.material_name);
 
       // 選択された単位IDを適用するための遅延。DOMの更新後に単位を設定するために必要。
@@ -230,4 +234,13 @@ function handleCountDownClick(event) {
   formCount_back--; // バックエンド用のフォーム数をデクリメント
   updateFormNumbers(); // フォーム番号を更新
   updateMaxCountText(formCount_view, maxFormCount_view) // 最大フォーム数テキストを更新
+}
+
+function formatQuantity(quantity) {
+  // 10進数を意味する基数を定数として定義
+  const decimalBase = 10;
+  // quantityを数値に変換
+  var numQuantity = parseFloat(quantity);
+  // 数値が整数かどうかをチェックし、整数の場合は小数点以下を削除
+  return numQuantity == parseInt(numQuantity, decimalBase) ? parseInt(numQuantity, decimalBase) : numQuantity;
 }

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -7,7 +7,7 @@ class Menu < ApplicationRecord
 
   validates :menu_name, presence: true, length: { maximum: 15 }
   validates :menu_contents, presence: true, length: { maximum: 20 }
-  validates :contents, presence: true, length: { maximum: 700 }
+  validates :contents, presence: true, length: { maximum: 1500 }
   before_validation :set_default_image
 
   # 複数のingredientデータを格納するために設定しています。

--- a/app/views/menus/_form_fields.html.erb
+++ b/app/views/menus/_form_fields.html.erb
@@ -10,7 +10,7 @@
 
 <div id="menu-error-contents" class="menu-error"></div>
 <div class="content-field">
-  <%= f.text_area :contents, id: "contents", autofocus: true, autocomplete: "contents", placeholder: "作り方(最大700字)", maxlength: 700 %>
+  <%= f.text_area :contents, id: "contents", autofocus: true, autocomplete: "contents", placeholder: "作り方(最大1500字)", maxlength: 1500 %>
 </div>
 
 <div class="image-field">

--- a/app/views/menus/confirm.html.erb
+++ b/app/views/menus/confirm.html.erb
@@ -59,7 +59,7 @@
               <div class="ingredient-item">
                 <p class="material-name"><%= aggregated_ingredient.material.material_name %></p>
                 <div class="quantity-unit">
-                  <p class="quantity"><%= aggregated_ingredient.quantity %></p>
+                  <p class="quantity"><%= display_quantity(aggregated_ingredient.quantity) %></p>
                   <p class="unit"><%= aggregated_ingredient.unit.unit_name %></p>
                 </div>
               </div>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -48,7 +48,7 @@
             <div class="ingredient-show-item">
               <p class="material-name"><%= aggregated_ingredient.material.material_name %></p>
               <div class="quantity-unit">
-                <p class="quantity"><%= aggregated_ingredient.quantity %></p>
+                <p class="quantity"><%= display_quantity(aggregated_ingredient.quantity) %></p>
                 <p class="unit"><%= aggregated_ingredient.unit.unit_name %></p>
               </div>
             </div>

--- a/db/migrate/20230908032753_create_ingredients.rb
+++ b/db/migrate/20230908032753_create_ingredients.rb
@@ -4,7 +4,7 @@ class CreateIngredients < ActiveRecord::Migration[7.0]
       t.string :material_name,      null: false
       t.references :material,       null: false
       t.references :unit,           null: false
-      t.integer :quantity
+      t.decimal :quantity, precision: 4, scale: 1
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,7 +69,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_04_041549) do
     t.string "material_name", null: false
     t.bigint "material_id", null: false
     t.bigint "unit_id", null: false
-    t.integer "quantity"
+    t.decimal "quantity", precision: 4, scale: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["material_id"], name: "index_ingredients_on_material_id"


### PR DESCRIPTION
目的：
食材の数量をより正確に管理するため、データベースのスキーマを変更し、数量を小数点第一位まで保存できるようにすることが目的です。これにより、特に0.5のような小数を正確に扱うことが可能になり、ユーザーがより細かく食材を登録できるようになります。

内容：
・Ingredientモデルの「quantity」カラムのデータ型を「integer」から「decimal」に変更
・関連するビューでの数量表示を更新し、小数点以下が0の場合は整数として、そうでない場合は小数として表示するよう修正

献立詳細画面：
<img width="935" alt="スクリーンショット 2023-12-07 19 45 05" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/29ac8b77-176e-4cd1-b3f3-4b336ba7cb6d">

献立編集画面展開時：
<img width="963" alt="スクリーンショット 2023-12-07 19 45 18" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/0ffae355-01ad-4fc0-9fbd-0967ae737a2c">

確認画面：
<img width="949" alt="スクリーンショット 2023-12-07 19 45 27" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/11b42cbc-da15-4443-9c9e-83dc0afb1ee6">
