### PR TITLE
MenuとIngredientモデルに関連付けのモデルに対してdependent::destroyオプションを追加

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -243,8 +243,6 @@ class MenusController < ApplicationController
 
         # 既存の食材データを削除する
         ingredients.destroy_all
-        # 関連する MenuIngredient レコードを削除
-        MenuIngredient.where(menu_id: menu.id).destroy_all
 
         # メニューデータを更新
         menu.update!(menu_params)
@@ -252,7 +250,6 @@ class MenusController < ApplicationController
         # 新しい食材データを保存
         if ingredient_data.present?
           ingredient_data.each do |ingredient|
-            puts "食材を保存中: #{ingredient.inspect}"
             ingredient.save!
             MenuIngredient.create!(menu_id: menu.id, ingredient_id: ingredient.id)
           end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,5 +1,5 @@
 class Ingredient < ApplicationRecord
-  has_many :menu_ingredients
+  has_many :menu_ingredients, dependent: :destroy
   has_many :menus, through: :menu_ingredients
   belongs_to :material
   belongs_to :unit

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,9 +1,10 @@
 class Menu < ApplicationRecord
-  has_many :menu_users
+  has_many :menu_users, dependent: :destroy
   has_many :users, through: :menu_users
   has_one_attached :image
+  has_many :menu_ingredients, dependent: :destroy
   has_many :ingredients, through: :menu_ingredients, autosave: false
-  has_many :cart_items
+  has_many :cart_items, dependent: :destroy
 
   validates :menu_name, presence: true, length: { maximum: 15 }
   validates :menu_contents, presence: true, length: { maximum: 20 }


### PR DESCRIPTION
目的：
Menu モデルと Ingredient モデル間の関連付けを管理する中間モデルに dependent::destroy オプションを追加し、コントローラーの処理で余計な削除処理を削減することが目的です。

内容：
・MenuモデルとIngredientモデルの間の中間モデルに dependent::destroy オプションを追加
・MenuモデルとUserモデルの間の中間モデルに dependent::destroy オプションを追加
・Menuモデルに関しては関連のCartItemsモデルに対しても dependent::destroy オプションを追加
・app/controllers/menus_controller.rbで行っていたMenuIngredient レコードを削除する不要なコードを削除