### PR TITLE
買い物リストと関連する献立を管理するモデルを追加、アソシエーション設定

### DIFF
--- a/app/models/completed_menu.rb
+++ b/app/models/completed_menu.rb
@@ -1,0 +1,5 @@
+class CompletedMenu < ApplicationRecord
+  belongs_to :user
+  has_many :completed_menu_items, dependent: :destroy
+  has_many :menus, through: :completed_menu_items
+end

--- a/app/models/completed_menu_item.rb
+++ b/app/models/completed_menu_item.rb
@@ -1,0 +1,4 @@
+class CompletedMenuItem < ApplicationRecord
+  belongs_to :completed_menu
+  belongs_to :menu
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -3,6 +3,7 @@ class Ingredient < ApplicationRecord
   has_many :menus, through: :menu_ingredients
   belongs_to :material
   belongs_to :unit
+  has_many :shopping_list_items
 
   validates :material_name, presence: true
   validates :material_id, presence: true, length: { maximum: 15 }

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -5,6 +5,8 @@ class Menu < ApplicationRecord
   has_many :menu_ingredients, dependent: :destroy
   has_many :ingredients, through: :menu_ingredients, autosave: false
   has_many :cart_items, dependent: :destroy
+  has_many :completed_menu_items, dependent: :destroy
+  has_many :completed_menus, through: :completed_menu_items
 
   validates :menu_name, presence: true, length: { maximum: 15 }
   validates :menu_contents, presence: true, length: { maximum: 20 }

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -1,0 +1,4 @@
+class ShoppingList < ApplicationRecord
+  belongs_to :user
+  has_many :shopping_list_items, dependent: :destroy
+end

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -1,0 +1,4 @@
+class ShoppingListItem < ApplicationRecord
+  belongs_to :shopping_list
+  belongs_to :ingredient
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   attr_accessor :current_password
 
-  has_many :menu_users
+  has_many :menu_users, dependent: :destroy
   has_many :menus, through: :menu_users
-  has_one :cart
+  has_one :cart, dependent: :destroy
+  has_many :completed_menus, dependent: :destroy
+  has_many :shopping_lists, dependent: :destroy
 end

--- a/db/migrate/20231207143532_create_completed_menus.rb
+++ b/db/migrate/20231207143532_create_completed_menus.rb
@@ -1,0 +1,9 @@
+class CreateCompletedMenus < ActiveRecord::Migration[7.0]
+  def change
+    create_table :completed_menus do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231207143547_create_completed_menu_items.rb
+++ b/db/migrate/20231207143547_create_completed_menu_items.rb
@@ -1,0 +1,10 @@
+class CreateCompletedMenuItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :completed_menu_items do |t|
+      t.references :completed_menu, null: false, foreign_key: true
+      t.references :menu, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231207143617_create_shopping_lists.rb
+++ b/db/migrate/20231207143617_create_shopping_lists.rb
@@ -1,0 +1,9 @@
+class CreateShoppingLists < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shopping_lists do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231207143631_create_shopping_list_items.rb
+++ b/db/migrate/20231207143631_create_shopping_list_items.rb
@@ -1,0 +1,11 @@
+class CreateShoppingListItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shopping_list_items do |t|
+      t.references :shopping_list, null: false, foreign_key: true
+      t.references :ingredient, null: false, foreign_key: true
+      t.boolean :checked
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_04_041549) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_07_143631) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,6 +65,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_04_041549) do
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
   end
 
+  create_table "completed_menu_items", force: :cascade do |t|
+    t.bigint "completed_menu_id", null: false
+    t.bigint "menu_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["completed_menu_id"], name: "index_completed_menu_items_on_completed_menu_id"
+    t.index ["menu_id"], name: "index_completed_menu_items_on_menu_id"
+  end
+
+  create_table "completed_menus", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_completed_menus_on_user_id"
+  end
+
   create_table "ingredients", force: :cascade do |t|
     t.string "material_name", null: false
     t.bigint "material_id", null: false
@@ -115,6 +131,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_04_041549) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "shopping_list_items", force: :cascade do |t|
+    t.bigint "shopping_list_id", null: false
+    t.bigint "ingredient_id", null: false
+    t.boolean "checked"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ingredient_id"], name: "index_shopping_list_items_on_ingredient_id"
+    t.index ["shopping_list_id"], name: "index_shopping_list_items_on_shopping_list_id"
+  end
+
+  create_table "shopping_lists", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_shopping_lists_on_user_id"
+  end
+
   create_table "units", force: :cascade do |t|
     t.string "unit_name", default: "", null: false
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
@@ -148,4 +181,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_04_041549) do
   add_foreign_key "cart_items", "carts"
   add_foreign_key "cart_items", "menus"
   add_foreign_key "carts", "users"
+  add_foreign_key "completed_menu_items", "completed_menus"
+  add_foreign_key "completed_menu_items", "menus"
+  add_foreign_key "completed_menus", "users"
+  add_foreign_key "shopping_list_items", "ingredients"
+  add_foreign_key "shopping_list_items", "shopping_lists"
+  add_foreign_key "shopping_lists", "users"
 end

--- a/test/fixtures/completed_menu_items.yml
+++ b/test/fixtures/completed_menu_items.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  completed_menu: one
+  menu: one
+
+two:
+  completed_menu: two
+  menu: two

--- a/test/fixtures/completed_menus.yml
+++ b/test/fixtures/completed_menus.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+
+two:
+  user: two

--- a/test/fixtures/shopping_list_items.yml
+++ b/test/fixtures/shopping_list_items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  shopping_list: one
+  ingredient: one
+  checked: false
+
+two:
+  shopping_list: two
+  ingredient: two
+  checked: false

--- a/test/fixtures/shopping_lists.yml
+++ b/test/fixtures/shopping_lists.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+
+two:
+  user: two

--- a/test/models/completed_menu_item_test.rb
+++ b/test/models/completed_menu_item_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CompletedMenuItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/completed_menu_test.rb
+++ b/test/models/completed_menu_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CompletedMenuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/shopping_list_item_test.rb
+++ b/test/models/shopping_list_item_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ShoppingListItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/shopping_list_test.rb
+++ b/test/models/shopping_list_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ShoppingListTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
買い物リストとそれに関連する献立を効率的に管理するためにモデルとアソシエーションの設定を行います。

内容：
・CompletedMenuモデルを追加し、ユーザーが完了した献立を追跡できるように設定
・CompletedMenuItems中間モデルを追加し、CompletedMenuとMenu間の多対多の関係を管理
・ShoppingListおよびShoppingListItemモデルを追加し、ユーザーの買い物リストとそれに含まれる項目の管理
・上記モデル間でdependent: :destroyアソシエーションを設定し、データの整合性を維持

ER図：
<img width="949" alt="スクリーンショット 2023-12-08 0 39 15" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/82ff8b5a-8045-4d1a-a9f5-9a6b756cef9c">
