### PR TITLE
ShoppingListItemとShoppingListMenuの設定、およびリレーションの更新

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,4 @@
 class Category < ApplicationRecord
   has_many :materials
+  has_many :shopping_list_items
 end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -3,4 +3,5 @@ class Material < ApplicationRecord
   has_one :ingredient
   has_many :material_units
   has_many :units, through: :material_units
+  has_many :shopping_list_items
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -5,6 +5,8 @@ class Menu < ApplicationRecord
   has_many :menu_ingredients, dependent: :destroy
   has_many :ingredients, through: :menu_ingredients, autosave: false
   has_many :cart_items, dependent: :destroy
+  has_many :shopping_list_menus, dependent: :restrict_with_exception
+  has_many :shopping_lists, through: :shopping_list_menus
 
   validates :menu_name, presence: true, length: { maximum: 15 }
   validates :menu_contents, presence: true, length: { maximum: 20 }

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -1,3 +1,6 @@
 class ShoppingList < ApplicationRecord
   belongs_to :cart
+  has_many :shopping_list_items, dependent: :destroy
+  has_many :shopping_list_menus
+  has_many :menus, through: :shopping_list_menus
 end

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -1,0 +1,6 @@
+class ShoppingListItem < ApplicationRecord
+  belongs_to :shopping_list
+  belongs_to :material
+  belongs_to :unit
+  belongs_to :category
+end

--- a/app/models/shopping_list_menu.rb
+++ b/app/models/shopping_list_menu.rb
@@ -1,0 +1,4 @@
+class ShoppingListMenu < ApplicationRecord
+  belongs_to :shopping_list
+  belongs_to :menu
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,4 +1,5 @@
 class Unit < ApplicationRecord
   has_many :material_units
   has_many :materials, through: :material_units
+  has_many :shopping_list_items
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   # CartItem#createへのルーティング
   resources :cart_items, only: [:create, :destroy]
+  resources :shopping_lists
 
   # カートアイテムの数量を増やす
   post '/cart_items/:id/increment', to: 'cart_items#increment', as: 'cart_item_increment'

--- a/db/migrate/20231211033342_create_shopping_list_items.rb
+++ b/db/migrate/20231211033342_create_shopping_list_items.rb
@@ -1,0 +1,14 @@
+class CreateShoppingListItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shopping_list_items do |t|
+      t.references :shopping_list, null: false, foreign_key: true
+      t.references :material, null: false, foreign_key: true
+      t.decimal :quantity
+      t.references :unit, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
+      t.boolean :is_checked
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231211081014_create_shopping_list_menus.rb
+++ b/db/migrate/20231211081014_create_shopping_list_menus.rb
@@ -1,0 +1,10 @@
+class CreateShoppingListMenus < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shopping_list_menus do |t|
+      t.references :shopping_list, null: false, foreign_key: true
+      t.references :menu, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_07_143617) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_11_081014) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -132,6 +132,30 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_07_143617) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "shopping_list_items", force: :cascade do |t|
+    t.bigint "shopping_list_id", null: false
+    t.bigint "material_id", null: false
+    t.decimal "quantity"
+    t.bigint "unit_id", null: false
+    t.bigint "category_id", null: false
+    t.boolean "is_checked"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_shopping_list_items_on_category_id"
+    t.index ["material_id"], name: "index_shopping_list_items_on_material_id"
+    t.index ["shopping_list_id"], name: "index_shopping_list_items_on_shopping_list_id"
+    t.index ["unit_id"], name: "index_shopping_list_items_on_unit_id"
+  end
+
+  create_table "shopping_list_menus", force: :cascade do |t|
+    t.bigint "shopping_list_id", null: false
+    t.bigint "menu_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["menu_id"], name: "index_shopping_list_menus_on_menu_id"
+    t.index ["shopping_list_id"], name: "index_shopping_list_menus_on_shopping_list_id"
+  end
+
   create_table "shopping_lists", force: :cascade do |t|
     t.bigint "cart_id", null: false
     t.datetime "created_at", null: false
@@ -175,5 +199,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_07_143617) do
   add_foreign_key "completed_menu_items", "completed_menus"
   add_foreign_key "completed_menu_items", "menus"
   add_foreign_key "completed_menus", "users"
+  add_foreign_key "shopping_list_items", "categories"
+  add_foreign_key "shopping_list_items", "materials"
+  add_foreign_key "shopping_list_items", "shopping_lists"
+  add_foreign_key "shopping_list_items", "units"
+  add_foreign_key "shopping_list_menus", "menus"
+  add_foreign_key "shopping_list_menus", "shopping_lists"
   add_foreign_key "shopping_lists", "carts"
 end

--- a/test/fixtures/shopping_list_items.yml
+++ b/test/fixtures/shopping_list_items.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  shopping_list: one
+  material: one
+  quantity: 9.99
+  unit: one
+  category: one
+  is_checked: false
+
+two:
+  shopping_list: two
+  material: two
+  quantity: 9.99
+  unit: two
+  category: two
+  is_checked: false

--- a/test/fixtures/shopping_list_menus.yml
+++ b/test/fixtures/shopping_list_menus.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  shopping_list: one
+  menu: one
+
+two:
+  shopping_list: two
+  menu: two

--- a/test/models/shopping_list_item_test.rb
+++ b/test/models/shopping_list_item_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ShoppingListItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/shopping_list_menu_test.rb
+++ b/test/models/shopping_list_menu_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ShoppingListMenuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
ユーザーが買い物リスト上で行ったチェックの状態をデータベースに保存し、アプリケーションのセッションやリロード後もその状態がリセットされないようにするためのものです。

内容：
・ShoppingListItemモデルを作成
・ShoppingListItemモデルに Material、Unit、Category へのリレーションを追加
・ShoppingListMenuを作成
・ShoppingListモデルとMenuモデル間の多対多の関係を管理するためのリレーションを設定

ER図：
<img width="1002" alt="スクリーンショット 2023-12-11 17 57 47" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/853e9ac8-fa94-45a4-b110-923e4b1855c6">

