### PR TITLE
買い物リストのviewをindex.html.erbで作成＋controllerを一部修正

### DIFF
--- a/app/assets/stylesheets/shared/_styles.scss
+++ b/app/assets/stylesheets/shared/_styles.scss
@@ -110,7 +110,6 @@
   }
 }
 
-
 @mixin menus_list {
   display: flex;
   flex-wrap: wrap;
@@ -147,4 +146,43 @@
 
 @mixin rounded-image {
   border-radius: 20px;
+}
+
+@mixin menu-heading {
+  display: block;
+  margin-top: 10px;
+  margin-bottom: 30px;
+  font-size: 30px;
+  position: relative;
+  display: inline-block;
+  padding-bottom: 5px;
+  @media screen and (max-width: 460px) {
+    display: inline-block;
+    font-size: 20px;
+  }
+}
+
+@mixin menu-heading{
+  display: block;
+  margin-top: 50px;
+  font-size: 30px;
+  position: relative;
+  display: inline-block;
+  padding-bottom: 5px;
+  @media screen and (max-width: 460px) {
+    display: inline-block;
+    font-size: 20px;
+  }
+}
+
+@mixin menu-heading-after {
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background-color: #000000;
+  }
 }

--- a/app/assets/stylesheets/shopping-list.scss
+++ b/app/assets/stylesheets/shopping-list.scss
@@ -1,0 +1,215 @@
+@import 'shared/menuForm';
+@import 'shared/styles';
+
+.shopping-list-container{
+  @include menu-container;
+  @media screen and (max-width: 1000px) {
+    width: 100;
+    height: 200%;
+  }
+
+  .list-title{
+    @include menu-heading;
+    @include menu-heading-after;
+  }
+
+  .list-title h3{
+    margin-bottom: 0;
+  }
+
+  .cooking-menu-list{
+    display: block;
+    margin-top: 30px;
+    width: 100%;
+    @media screen and (max-width: 600px) {
+      border: 2px solid #000000;
+      border-radius: 20px;
+      width: 80%;
+    }
+
+    .list-contents-title{
+      font-size: 20px;
+      text-decoration: underline;
+      text-align:  center;
+    }
+
+    .shopping-menu-list{
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      align-items: center;
+      width: 100%;
+      @media screen and (max-width: 600px) {
+        display: block;
+        margin-top: 30px;
+      }
+
+      .menu-list{
+        display: flex;
+        margin: 10px;
+        @media screen and (max-width: 600px) {
+          height: 27px;
+        }
+
+        .menu-item{
+          width: 100%;
+          @media screen and (max-width: 600px) {
+            height: 30px;
+            width: 60%;
+          }
+
+          .menu-image{
+            @media screen and (max-width: 600px) {
+              display: none;
+            }
+          }
+          .menu-name{
+            text-align: center;
+            @media screen and (max-width: 600px) {
+              font-size: 18px;
+              margin-right: 10px;
+              text-align: right;
+            }
+          }
+        }
+
+        .menu-item-counts{
+          @media screen and (max-width: 600px) {
+            width: 40%;
+          }
+        }
+
+        .menu-item-counts p {
+          font-size: 25px;
+          margin-top: 30px;
+          width: 50px;
+          @media screen and (max-width: 600px) {
+            font-size: 18px;
+            margin-top: 0px;
+          }
+        }
+      }
+    }
+  }
+
+  .shopping-ingredient-list{
+    width: 50%;
+    @media screen and (max-width: 1000px) {
+      width: 80%;
+    }
+
+    ul{
+      padding: 0%;
+    }
+
+    .list-contents-title{
+      font-size: 20px;
+      text-decoration: underline;
+      text-align:  center;
+      padding-top: 20px;
+    }
+
+    .ingredient-list{
+      width: 100%;
+      text-align:  center;
+      margin-bottom: 60px;
+
+      .category-list p{
+        font-size: 17px;
+        margin-top: 0px;
+        height: 40px;
+      }
+
+      .category-list{
+        background-color: rgb(255, 212, 175);
+        text-align: center;
+        padding-top: 12px;
+      }
+
+      .ingredient-item {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        width: 100%;
+        margin: auto;
+        border-bottom: 2px solid hsla(0, 0%, 0%, 0.3);
+
+        .custom-checkbox-label {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin-right: 10px;
+          position: relative;
+
+          .custom-checkbox {
+            display: none;
+
+            &:checked + .checkmark {
+              background-color: orange; // チェック時の背景色
+              &:after {
+                content: '';
+                position: absolute;
+                left: 50%;
+                top: 50%;
+                width: 15px;
+                height: 15px;
+                background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="%23ffffff" d="M9 16.2l-4.2-4.2-1.4 1.4 5.6 5.6 12-12-1.4-1.4z"/></svg>');
+                background-size: contain;
+                background-repeat: no-repeat;
+                background-position: center;
+                transform: translate(-50%, -50%);
+              }
+            }
+          }
+
+          .checkmark {
+            display: block;
+            height: 30px;
+            width: 30px;
+            background-color: #eee;
+            border-radius: 50%;
+            border: 1px solid #ddd;
+            cursor: pointer;
+            position: relative;
+          }
+        }
+
+        .material-name {
+          flex-grow: 1;
+          font-size: 16px;
+          text-align: left;
+          margin-left: 10px;
+        }
+
+        .quantity-unit {
+          display: flex;
+          justify-content: flex-end;
+          align-items: center;
+          flex-grow: 0;
+          width: auto;
+          margin-left: 10px;
+        }
+      }
+    }
+  }
+
+  .button-container{
+    .shopping-complete-button{
+      .complete-button{
+        @include button;
+        width: 100%;
+        margin-bottom: 10px;
+        margin-top: 20px;
+        background-color: rgba(#1E9AF4, 0.3);
+        cursor: auto;
+      }
+    }
+
+    .back-button{
+      @include button;
+      width: 100%;
+      margin-bottom: 10px;
+      margin-top: 20px;
+    }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,9 @@ class ApplicationController < ActionController::Base
     cart = current_user.cart
     @cart_items = cart.cart_items.includes(:menu) if cart
   end
+
+  def handle_general_error
+    flash[:error] = "登録中に予期せぬエラーが発生しました。"
+    redirect_to root_path
+  end
 end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -316,11 +316,6 @@ class MenusController < ApplicationController
     "data:#{uploaded_file.content_type};base64,#{Base64.strict_encode64(uploaded_file.read)}"
   end
 
-  def handle_general_error
-    flash[:error] = "登録中に予期せぬエラーが発生しました。"
-    redirect_to root_path
-  end
-
   def paginate(query)
     # 定数 FIRST_PAGE はページネーションで使用される最初のページ番号を定義します。
     # 通常、ページ番号は1から始まります。

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -1,1 +1,74 @@
-<%= @shopping_lists %>
+<div class="shopping-list-container", id: 'shopping-list-container'>
+
+  <div class="list-title">
+    <h3>買い物リスト</h3>
+  </div>
+
+  <div class="cooking-menu-list">
+    <div class="list-contents-title">
+      <p>作る予定の献立</p>
+    </div>
+
+    <div class="shopping-menu-list">
+      <% @menus.each do |menu_date| %>
+        <div class="menu-list">
+          <div class="menu-item">
+
+            <div class="menu-image">
+              <%= image_tag(rails_blob_path(menu_date.image.variant(resize_to_fill: [80, 80])), class: "rounded-image") %>
+            </div>
+
+            <div class="menu-name">
+              <%= truncate(menu_date.menu_name, length: 7, omission: '..') %>
+            </div>
+          </div>
+
+          <div class="menu-item-counts">
+            <p>× <%= @menu_item_counts[menu_date.id] %></p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="shopping-ingredient-list">
+    <div class="list-contents-title">
+      <p>購入品一覧</p>
+    </div>
+
+    <div class="ingredient-list">
+      <% if @shopping_lists.empty? %>
+        <p>購入する食材はありません。</p>
+      <% else %>
+        <% @shopping_lists.each do |category_id, ingredients| %>
+          <div class="category-list">
+            <p><%= @categories[category_id] %></p>
+          </div>
+          <ul>
+            <% ingredients.each do |ingredient| %>
+              <div class="ingredient-item">
+                <label class="custom-checkbox-label">
+                  <%= check_box_tag "ingredients[#{ingredient.id}]", ingredient.id, false, class: "custom-checkbox" %>
+                  <span class="checkmark"></span>
+                </label>
+                <p class="material-name"><%= ingredient.material.material_name %></p>
+                <div class="quantity-unit">
+                  <p class="quantity"><%= display_quantity(ingredient.quantity) %></p>
+                  <p class="unit"><%= ingredient.unit.unit_name %></p>
+                </div>
+              </div>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="button-container">
+      <div class="shopping-complete-button">
+        <%= button_to '買い物完了', root_path, method: :get, class: 'complete-button', id: 'complete-button' %>
+      </div>
+      <%= button_to '戻る', root_path, method: :get, class: 'back-button', id: 'back_button' %>
+    </div>
+
+  </div>
+</div>

--- a/db/migrate/20231204041549_create_cart_items.rb
+++ b/db/migrate/20231204041549_create_cart_items.rb
@@ -4,7 +4,6 @@ class CreateCartItems < ActiveRecord::Migration[7.0]
       t.references :cart, null: false, foreign_key: true
       t.references :menu, null: false, foreign_key: true
       t.integer :item_count
-      t.boolean :is_listed, default: false, null: false
 
       t.timestamps
     end

--- a/db/migrate/20231211081014_create_shopping_list_menus.rb
+++ b/db/migrate/20231211081014_create_shopping_list_menus.rb
@@ -3,6 +3,7 @@ class CreateShoppingListMenus < ActiveRecord::Migration[7.0]
     create_table :shopping_list_menus do |t|
       t.references :shopping_list, null: false, foreign_key: true
       t.references :menu, null: false, foreign_key: true
+      t.integer :menu_count
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,7 +46,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_081014) do
     t.bigint "cart_id", null: false
     t.bigint "menu_id", null: false
     t.integer "item_count"
-    t.boolean "is_listed", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["cart_id"], name: "index_cart_items_on_cart_id"
@@ -150,6 +149,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_081014) do
   create_table "shopping_list_menus", force: :cascade do |t|
     t.bigint "shopping_list_id", null: false
     t.bigint "menu_id", null: false
+    t.integer "menu_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["menu_id"], name: "index_shopping_list_menus_on_menu_id"


### PR DESCRIPTION
目的：
ユーザーが買い物リストを閲覧できるようにするために、index.html.erb における買い物リストのビューを作成し、それに伴い必要なコントローラーの修正を行うことが目的です。

内容：
・index.html.erb に買い物リストのビューを新規作成
・viewでは食材がカテゴリごとに表示されるよう設定
・食材にはそれぞれチェックボックスを設定
※viewの「買い物完了ボタン」はチェックボックスがすべてtrueの場合に押せるよう設定したいため、基本は透過したデザインに設定しています。この機能は後日実装予定

・ShoppingListsController の index アクションを修正し、ビューに表示するデータの取得方法を最適化

備考：
献立リストのビューは作成されましたが、現在の実装では買い物途中でリストを更新するというユーザーの実際のニーズや業務フローに対応していません。これにより、一度リストが作成されると、新たなリストを作成することができなくなる問題が生じています。この状況は、機能の完成度がまだ十分でないことを示しており、ユーザーが複数のリストを作成し管理するための追加の調整や機能強化が必要です。


<img width="998" alt="スクリーンショット 2023-12-12 22 53 41" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/6642e1fc-d2f9-4406-904e-3dac21d0fe79">
<img width="958" alt="スクリーンショット 2023-12-12 22 53 49" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/90cfd8ca-675c-4fcb-a8b1-d29796b023e4">
<img width="908" alt="スクリーンショット 2023-12-12 23 00 33" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/12875dcb-7581-4d37-ae7e-ba8eb07228a4">
<img width="461" alt="スクリーンショット 2023-12-12 22 59 55" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/033f9de2-9b43-4fc6-a30e-8b49eb42c4bd">

