### PR TITLE
カスタムチェックボックスが全て選択された場合にのみ「購入完了」ボタンを有効にする機能を追加

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,3 +4,4 @@ import "controllers"
 import jquery from "jquery"
 window.$ = jquery
 import "./nav_menu";
+import "./checkbox-button-control";

--- a/app/javascript/checkbox-button-control.js
+++ b/app/javascript/checkbox-button-control.js
@@ -1,0 +1,46 @@
+document.addEventListener('turbo:load', function() {
+
+  let shoppingListContainer = document.getElementById('complete-button');
+
+  if (!shoppingListContainer) return;
+
+  // 全てのチェックボックスを取得
+  let checkboxes = document.querySelectorAll('.custom-checkbox');
+
+  // チェックボックスの総数を取得
+  let boxCount = checkboxes.length;
+
+  // ボタン要素を取得
+  let button = document.getElementById('complete-button');
+
+  // チェックボックスが0個の場合、ボタンを有効化してスタイルを適用し、処理を終了
+  if (boxCount === 0) {
+    button.style.backgroundColor = '#1E9AF4';
+    button.style.cursor = 'pointer';
+    return;
+  }
+
+  // ボタンの初期状態を無効化に設定
+  button.disabled = true;
+
+  // 各チェックボックスにイベントリスナーを設定
+  checkboxes.forEach(checkbox => {
+    checkbox.addEventListener('change', () => {
+        // チェックされたチェックボックスの数をカウント
+        let checkedCount = document.querySelectorAll('.custom-checkbox:checked').length;
+
+        // 全てのチェックボックスがチェックされていればボタンを有効化
+        button.disabled = !(checkedCount === boxCount);
+
+        // ボタンが有効の場合、特定の背景色に変更
+        if (!button.disabled) {
+          button.style.backgroundColor = '#1E9AF4';
+          button.style.cursor = 'pointer';
+        } else {
+          // ボタンが無効の場合、SCSSで設定された背景色を使う
+          button.style.backgroundColor = '';
+          button.style.cursor = 'auto';
+        }
+    });
+  });
+});


### PR DESCRIPTION
目的：
必要な全項目の確認が完了するまでユーザーが誤って購入プロセスを進めるのを防ぐことが目的です。

内容：
・全ての .custom-checkbox 要素に対してイベントリスナーを設定
・全てのチェックボックスがチェックされた場合にのみ、#complete-button 要素の無効化を解除するよう設定


<img width="966" alt="スクリーンショット 2023-12-13 11 48 10" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/83223b4b-9dc7-4438-890c-0c48814ffd4c">
<img width="1067" alt="スクリーンショット 2023-12-13 11 48 17" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/4d730378-35b0-4312-817b-5e0b9ccc8252">
