### PR TITLE
献立名の表示をtruncateで短縮し、ビューデザインに合わせる

### DIFF
--- a/app/views/menus/custom_menus.html.erb
+++ b/app/views/menus/custom_menus.html.erb
@@ -12,7 +12,7 @@
           <%= link_to user_menu_path(current_user, menu), class: "menu-item-link", data: { turbo: false } do %>
             <div class="menu-item">
               <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
-              <div class="menu-item-title"><%= menu.menu_name %></div>
+              <div class="menu-item-title"><%= truncate(menu.menu_name, length: 10, omission: '..') %></div>
             </div>
           <% end %>
         <% end %>

--- a/app/views/menus/sample_menus.html.erb
+++ b/app/views/menus/sample_menus.html.erb
@@ -11,7 +11,7 @@
             <%= link_to user_menu_path(current_user, menu), class: "menu-item-link", data: { turbo: false } do %>
               <div class="menu-item">
                 <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
-                <div class="menu-item-title"><%= menu.menu_name %></div>
+                <div class="menu-item-title"><%= truncate(menu.menu_name, length: 10, omission: '..') %></div>
               </div>
             <% end %>
           <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,7 @@
           <%= button_to '✖️', cart_item_path(cart_item), method: :delete, class: "delete-button" %>
 
           <%= image_tag(rails_blob_path(cart_item.menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
-          <div class="menu-item-title"><%= cart_item.menu.menu_name %></div>
+          <div class="menu-item-title"><%= truncate(cart_item.menu.menu_name, length: 10, omission: '..') %></div>
 
           <div class="menu-item-count">
             <%= button_to '▲', cart_item_increment_path(cart_item), method: :post, data: { turbo_frame: "menu_item_quantity_#{cart_item.id}" }, class: "increment-button" %>


### PR DESCRIPTION
目的：
ビューで表示される献立名が一定の長さを超えるとレイアウトが崩れる問題に対処することが目的です。

内容：
・truncateメソッドを使用して、献立名の長さを適切に短縮
・オリジナル/サンプル献立リストの表示画面表示時に献立名の長さを短縮するよう設定

<img width="581" alt="スクリーンショット 2023-12-13 15 22 51" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/1d39814a-b1d2-4fb7-b733-ccb4a37894c2">
<img width="851" alt="スクリーンショット 2023-12-13 15 23 10" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/00014578-6916-4b82-b5f5-fa2ec90e0b27">
<img width="811" alt="スクリーンショット 2023-12-13 15 45 35" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/5e09d042-174d-497c-8d76-658f521ca195">


