### PR TITLE
開発者用のサンプル献立登録機能をサポートするためのマイグレーションファイルの更新

### DIFF
--- a/db/migrate/20230906234713_create_user_menus.rb
+++ b/db/migrate/20230906234713_create_user_menus.rb
@@ -1,8 +1,8 @@
 class CreateUserMenus < ActiveRecord::Migration[7.0]
   def change
     create_table :user_menus do |t|
-      t.references :user,                null: false
-      t.references :menu,                null: false
+      t.references :user
+      t.references :menu, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,7 +170,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_081014) do
   end
 
   create_table "user_menus", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.bigint "menu_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
目的：
開発者がサンプル献立を簡単に登録できるように、データベースのマイグレーションファイルを更新することが目的です。

内容：
・既存の CreateUserMenus マイグレーションファイルを変更し、t.references :user での null: false 制約を解除