### PR TITLE
献立再選択に応じた買い物リストの再編とナビバーからのアクセス機能追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,10 @@
 class ApplicationController < ActionController::Base
   include Devise::Controllers::Helpers
   before_action :load_settings
-  before_action :set_cart_items
+  before_action :check_shopping_list_menu_items
 
   private
 
-  #標準設定だとdeviseのデフォルトのview画面に飛ぶためリダイレクト先を再設定します。
   def authenticate_user!
     unless current_user
       redirect_to new_user_custom_session_path
@@ -17,9 +16,14 @@ class ApplicationController < ActionController::Base
     @settings = YAML.load_file(Rails.root.join('config', 'settings.yml'))
   end
 
-  def set_cart_items
+  # 現在のユーザーのカートに紐づくショッピングリストに関連するメニュー項目が存在するかをチェック
+  def check_shopping_list_menu_items
     cart = current_user.cart
-    @cart_items = cart.cart_items.includes(:menu) if cart
+    if cart && cart.shopping_list
+      @has_menu_items = cart.shopping_list.shopping_list_menus.exists?
+    else
+      @has_menu_items = false
+    end
   end
 
   def handle_general_error

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -27,54 +27,59 @@ class ShoppingListsController < ApplicationController
 
 
   def create
-    # ユーザーのカートを取得
-    cart = current_user.cart
-
-    # カートに紐づいたショッピングリストを取得
-    shopping_list = current_user.cart.build_shopping_list
-
-    # カートの中にあるmenu_idとその個数のデータを取得
-    cart_items = cart.cart_items
-
-    # menu_idとそのitem_countだけをハッシュとして取得
-    menu_item_counts = cart_items.each_with_object({}) do |cart_item, counts|
-      counts[cart_item.menu_id] = cart_item.item_count
-    end
-
-    # menuに関連するingredient_idを取得
-    menu_ingredients = cart_items.flat_map { |cart_item| cart_item.menu.menu_ingredients }
-
-    # 食材のレコードを複製する処理
-    ingredients_duplicated = []
-    menu_ingredients.each do |menu_ingredient|
-      # 対応する献立の数量を取得
-      menu_count = menu_item_counts[menu_ingredient.menu_id]
-
-      # 献立の数量分だけレコードを複製
-      menu_count.times do
-        duplicated_ingredient = menu_ingredient.dup
-        # 必要であれば他の属性もここで設定する
-        ingredients_duplicated << duplicated_ingredient
-      end
-    end
-
-    # ingredient_idに紐づく食材データを取得
-    ingredients = ingredients_duplicated.map(&:ingredient)
-
-    # 食材データを合算する
-    aggregated_ingredients = aggregate_ingredients(ingredients)
-
-    # カテゴリIDを格納するためのハッシュマップを初期化
-    ingredients_with_categories = {}
-    aggregated_ingredients.each do |ingredient|
-      material = Material.find_by(id: ingredient.material_id)
-      # Material に紐づくカテゴリIDをハッシュマップに追加
-      ingredients_with_categories[ingredient.material_id] = material.category_id
-    end
-
     begin
       ActiveRecord::Base.transaction do
-        shopping_list = current_user.cart.create_shopping_list!
+        # ユーザーのカートを取得
+        cart = current_user.cart
+        # カートの中にあるmenu_idとその個数のデータを取得
+        cart_items = cart.cart_items
+
+        shopping_list = cart.shopping_list
+
+        # ショッピングリストのデータがある場合には関連データをリセット
+        if shopping_list.present?
+          # 関連する shopping_list_items と shopping_list_menus を削除します。
+          shopping_list.shopping_list_items.delete_all
+          shopping_list.shopping_list_menus.delete_all
+        else
+          shopping_list = cart.create_shopping_list
+        end
+
+        # menu_idとそのitem_countだけをハッシュとして取得
+        menu_item_counts = cart_items.each_with_object({}) do |cart_item, counts|
+          counts[cart_item.menu_id] = cart_item.item_count
+        end
+
+        # menuに関連するingredient_idを取得
+        menu_ingredients = cart_items.flat_map { |cart_item| cart_item.menu.menu_ingredients }
+
+        # 食材のレコードを複製する処理
+        ingredients_duplicated = []
+        menu_ingredients.each do |menu_ingredient|
+          # 対応する献立の数量を取得
+          menu_count = menu_item_counts[menu_ingredient.menu_id]
+
+          # 献立の数量分だけレコードを複製
+          menu_count.times do
+            duplicated_ingredient = menu_ingredient.dup
+            # 必要であれば他の属性もここで設定する
+            ingredients_duplicated << duplicated_ingredient
+          end
+        end
+
+        # ingredient_idに紐づく食材データを取得
+        ingredients = ingredients_duplicated.map(&:ingredient)
+
+        # 食材データを合算する
+        aggregated_ingredients = aggregate_ingredients(ingredients)
+
+        # カテゴリIDを格納するためのハッシュマップを初期化
+        ingredients_with_categories = {}
+        aggregated_ingredients.each do |ingredient|
+          material = Material.find_by(id: ingredient.material_id)
+          # Material に紐づくカテゴリIDをハッシュマップに追加
+          ingredients_with_categories[ingredient.material_id] = material.category_id
+        end
 
         # 各食材をShoppingListItemとして保存
         aggregated_ingredients.each do |ingredient|
@@ -94,6 +99,8 @@ class ShoppingListsController < ApplicationController
             menu_count: item_count
           )
         end
+
+        cart_items.delete_all
       end
     rescue ActiveRecord::RecordInvalid
       handle_general_error

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,5 +3,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    cart = current_user.cart
+    @cart_items = cart.cart_items.includes(:menu) if cart
   end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,5 +1,5 @@
 class Cart < ApplicationRecord
   belongs_to :user
-  has_many :cart_items
-  has_one :shopping_list
+  has_many :cart_items, dependent: :destroy
+  has_one :shopping_list, dependent: :destroy
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -1,6 +1,6 @@
 class ShoppingList < ApplicationRecord
   belongs_to :cart
   has_many :shopping_list_items, dependent: :destroy
-  has_many :shopping_list_menus
+  has_many :shopping_list_menus, dependent: :destroy
   has_many :menus, through: :shopping_list_menus
 end

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -26,8 +26,8 @@
   <% if @has_menu_items %>
     <%= link_to "買い物リスト", shopping_lists_path, class: "mobile-menu-link" %>
   <% end %>
-  <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "mobile-menu-link" %>
   <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "mobile-menu-link" %>
+  <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "mobile-menu-link" %>
   <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "mobile-menu-link" %>
 </div>
 

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -5,8 +5,11 @@
   </div>
   <div class="menu-bar-right">
     <div id="menu" class="desktop-menu">
-      <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "menu-link" %>
+      <% if @has_menu_items %>
+        <%= link_to "買い物リスト", shopping_lists_path, class: "menu-link" %>
+      <% end %>
       <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "menu-link" %>
+      <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "menu-link" %>
       <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "menu-link" %>
     </div>
     <div class="mobile-menu-botton">
@@ -20,6 +23,9 @@
 </div>
 
 <div class="mobile-menu-content">
+  <% if @has_menu_items %>
+    <%= link_to "買い物リスト", shopping_lists_path, class: "mobile-menu-link" %>
+  <% end %>
   <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "mobile-menu-link" %>
   <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "mobile-menu-link" %>
   <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "mobile-menu-link" %>

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -67,7 +67,7 @@
       <div class="shopping-complete-button">
         <%= button_to '買い物完了', root_path, method: :get, class: 'complete-button', id: 'complete-button' %>
       </div>
-      <%= button_to '戻る', root_path, method: :get, class: 'back-button', id: 'back_button' %>
+      <%= button_to '戻る', '#', method: :get, class: 'back-button', id: 'back_button', onclick: "history.back(); return false;" %>
     </div>
 
   </div>


### PR DESCRIPTION
目的：
ユーザーが買い物中にリストを調整しやすくなり、使い勝手を向上させることが目的です。

内容：
・ユーザーが新しい献立を選択した場合、既存の買い物リストが自動的に更新されるよう修正
・どのページからでもナビゲーションバーを使用して買い物リストに素早くアクセスできるように設定
・どのページからでも買い物リストにアクセスできるため、買い物リストの戻るボタンを前ページへのリンクになるよう改善

備考：
この設定ではまだ「買い物完了ボタンを押した場合の処理」「既存の買い物リストを更新する前に注意喚起」などの設定はできていません。そのため現時点では「献立リストの更新」「既存献立リストの確認（※チェックボックスはリセットされる）」というアクションのみ実行可能です。

・PC画面時
<img width="1374" alt="スクリーンショット 2023-12-14 15 00 07" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/aecebc99-2927-4261-b223-50d53d9e96b4">
・画面縮小時
<img width="244" alt="スクリーンショット 2023-12-14 15 19 57" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/d1da22ae-bbb4-4d2f-9545-6250b337dfcc">

