### PR TITLE
ユーザーが買い出しに行く前に、既存の買い出しリストが上書きされることを通知する確認ダイアログを追加

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -35,6 +35,10 @@
   <div class="button-set-container">
     <%= button_to "オリジナル献立リスト", user_custom_menus_path(current_user), class: "button-style bg-custom-menu", method: :get %>
     <%= button_to "サンプル献立リスト", sample_menus_path, class: "button-style bg-standard-menu", method: :get %>
-    <%= button_to "買い出しに行く", shopping_lists_path, class: "button-style bg-shopping-list", method: :post, id: "shopping-list" %>
+    <% if @has_menu_items %>
+      <%= button_to "買い出しに行く", shopping_lists_path, class: "button-style bg-shopping-list", method: :post, id: "shopping-list", form: { data: { turbo_confirm: "既存の買い出しリストが上書きされます。本当に宜しいですか？" }} %>
+    <% else %>
+      <%= button_to "買い出しに行く", shopping_lists_path, class: "button-style bg-shopping-list", method: :post, id: "shopping-list" %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
目的：
ユーザーが新しい買い出しリストを作成する際、既存のリストがある場合、データが上書きされます。そのためユーザーが新たな買い出しに進む前に、既存のリストがある場合には上書きされることを通知する確認ダイアログを追加することで、不意のデータ損失を防ぐことを目的としています。

内容：
・買い出しに行く操作をトリガーとする確認ダイアログの表示機能を実装
・ダイアログは、`shopping_lists_path`に対するPOSTリクエストを送信する際に、条件分岐を用いて表示されるようにしました。`@has_menu_items`が`true`の場合のみ、ユーザーにリストが上書きされることを警告します。

<img width="512" alt="スクリーンショット 2023-12-14 17 30 21" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/aeb30f87-8561-4159-8a2c-aa8dc434618b">

