### PR TITLE
買い物リストのチェック状態をDB保存でページ移動後も維持するよう設定

### DIFF
--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -23,6 +23,11 @@ class ShoppingListsController < ApplicationController
 
     # カテゴリIDでソートした結果をインスタンス変数に代入
     @shopping_lists = shopping_list_items_by_category.sort_by { |category_id, _items| category_id }.to_h
+
+    # JSで動的にデータ更新するため、各カテゴリ内でアイテムをIDに基づいてソート
+    @shopping_lists.each do |category_id, items|
+      items.sort_by!(&:id)
+    end
   end
 
 
@@ -108,5 +113,10 @@ class ShoppingListsController < ApplicationController
     end
 
     redirect_to shopping_lists_path
+  end
+
+  def toggle_check
+    shopping_list_item = ShoppingListItem.find(params[:id])
+    shopping_list_item.update(is_checked: params[:is_checked])
   end
 end

--- a/app/javascript/shopping_list_checkbox_handlers.js
+++ b/app/javascript/shopping_list_checkbox_handlers.js
@@ -1,0 +1,32 @@
+
+setupCheckboxEventListeners()
+
+// チェックボックスのイベントを設定する関数
+function setupCheckboxEventListeners() {
+
+  let checkboxes = document.querySelectorAll('.custom-checkbox');
+  console.log(checkboxes);
+
+  checkboxes.forEach(checkbox => {
+    checkbox.addEventListener('change', (e) => {
+      const listId = e.target.value;
+      const isChecked = e.target.checked;
+
+      const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+      const url = `/shopping_lists/${listId}/toggle_check`;
+
+      console.log(url);
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': token
+        },
+        body: JSON.stringify({ is_checked: isChecked })
+      })
+      .then(response => response.json())
+    });
+  });
+}

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -48,7 +48,7 @@
             <% ingredients.each do |ingredient| %>
               <div class="ingredient-item">
                 <label class="custom-checkbox-label">
-                  <%= check_box_tag "ingredients[#{ingredient.id}]", ingredient.id, false, class: "custom-checkbox" %>
+                  <%= check_box_tag "ingredients[#{ingredient.id}]", ingredient.id, ingredient.is_checked, class: "custom-checkbox" %>
                   <span class="checkmark"></span>
                 </label>
                 <p class="material-name"><%= ingredient.material.material_name %></p>
@@ -69,6 +69,7 @@
       </div>
       <%= button_to '戻る', '#', method: :get, class: 'back-button', id: 'back_button', onclick: "history.back(); return false;" %>
     </div>
-
   </div>
 </div>
+
+<%= javascript_include_tag 'shopping_list_checkbox_handlers' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
   # カートアイテムの数量を減らす
   post '/cart_items/:id/decrement', to: 'cart_items#decrement', as: 'cart_item_decrement'
 
+  post '/shopping_lists/:id/toggle_check', to: 'shopping_lists#toggle_check', as: 'shopping_list_toggle_check'
+
   devise_for :users
   devise_scope :user do
     get 'users/registration', to: 'custom_registrations#new', as: :new_user_custom_registration


### PR DESCRIPTION
目的：
チェックボックスの状態がページのリロードや移動後もその状態を維持し、ユーザーが一時的にページを離れた場合、チェック状態を再度することで使い勝手を向上させることが目的です。

内容：
・チェックボックスの状態変更時に、その状態をデータベースに保存するための AJAX リクエストを処理する toggle_check アクションを ShoppingListsController に追加
・フロントエンドで、チェックボックスの状態が変更された際にこのアクションを呼び出す JavaScript の実装
・買い物リストページのチェックボックスを、データベースに保存された is_checked の値に基づいて初期化するロジックの追加
・コントローラーのindexアクションではデータがJSで動的に更新されるため、リストの表示順序が変更されないように各カテゴリ内でアイテムをIDに基づいてソートされるよう変更