### PR TITLE
献立リストで買い物完了ボタンの有効/無効状態に応じてマウスオーバー/アウトイベントを動的に追加/削除するよう修正

### DIFF
--- a/app/assets/stylesheets/shopping-list.scss
+++ b/app/assets/stylesheets/shopping-list.scss
@@ -202,6 +202,11 @@
         margin-top: 20px;
         background-color: rgba(#1E9AF4, 0.3);
         cursor: auto;
+
+        // @include button;のhover設定を打ち消すため設定
+        &:hover {
+          background-color: rgba(#1E9AF4, 0.3);
+        }
       }
     }
 

--- a/app/javascript/checkbox_button_control.js
+++ b/app/javascript/checkbox_button_control.js
@@ -1,17 +1,16 @@
 document.addEventListener('turbo:load', function() {
 
   let shoppingListContainer = document.getElementById('complete-button');
-
   if (!shoppingListContainer) return;
 
   // 全てのチェックボックスを取得
   let checkboxes = document.querySelectorAll('.custom-checkbox');
-
   // チェックボックスの総数を取得
   let boxCount = checkboxes.length;
-
   // ボタン要素を取得
   let button = document.getElementById('complete-button');
+  // チェックされたチェックボックスの数をカウント
+  let checkedCount = document.querySelectorAll('.custom-checkbox:checked').length;
 
   // チェックボックスが0個の場合、ボタンを有効化してスタイルを適用し、処理を終了
   if (boxCount === 0) {
@@ -20,27 +19,49 @@ document.addEventListener('turbo:load', function() {
     return;
   }
 
-  // ボタンの初期状態を無効化に設定
-  button.disabled = true;
+  if (boxCount === checkedCount){
+    button.style.backgroundColor = '#1E9AF4';
+    button.style.cursor = 'pointer';
+    button.addEventListener('mouseover', onMouseOver);
+    button.addEventListener('mouseout', onMouseOut);
+  }else{
+    button.disabled = true;
+    button.style.backgroundColor = '';
+    button.style.cursor = 'auto';
+    button.removeEventListener('mouseover', onMouseOver);
+    button.removeEventListener('mouseout', onMouseOut);
+  }
 
   // 各チェックボックスにイベントリスナーを設定
   checkboxes.forEach(checkbox => {
     checkbox.addEventListener('change', () => {
-        // チェックされたチェックボックスの数をカウント
-        let checkedCount = document.querySelectorAll('.custom-checkbox:checked').length;
 
-        // 全てのチェックボックスがチェックされていればボタンを有効化
-        button.disabled = !(checkedCount === boxCount);
+      let checkedCount = document.querySelectorAll('.custom-checkbox:checked').length;
 
-        // ボタンが有効の場合、特定の背景色に変更
-        if (!button.disabled) {
-          button.style.backgroundColor = '#1E9AF4';
-          button.style.cursor = 'pointer';
-        } else {
-          // ボタンが無効の場合、SCSSで設定された背景色を使う
-          button.style.backgroundColor = '';
-          button.style.cursor = 'auto';
-        }
+      // 全てのチェックボックスがチェックされていればボタンを有効化
+      button.disabled = !(checkedCount === boxCount);
+
+      // ボタンが有効の場合、特定の背景色に変更
+      if (!button.disabled) {
+        button.style.backgroundColor = '#1E9AF4';
+        button.style.cursor = 'pointer';
+        button.addEventListener('mouseover', onMouseOver);
+        button.addEventListener('mouseout', onMouseOut);
+      } else {
+        // ボタンが無効の場合、SCSSで設定された背景色を使う
+        button.style.backgroundColor = '';
+        button.style.cursor = 'auto';
+        button.removeEventListener('mouseover', onMouseOver);
+        button.removeEventListener('mouseout', onMouseOut);
+      }
     });
   });
 });
+
+function onMouseOver() {
+  this.style.backgroundColor = '#9dd2f9';
+}
+
+function onMouseOut() {
+  this.style.backgroundColor = '#1E9AF4';
+}

--- a/app/javascript/shopping_list_checkbox_handlers.js
+++ b/app/javascript/shopping_list_checkbox_handlers.js
@@ -5,7 +5,6 @@ setupCheckboxEventListeners()
 function setupCheckboxEventListeners() {
 
   let checkboxes = document.querySelectorAll('.custom-checkbox');
-  console.log(checkboxes);
 
   checkboxes.forEach(checkbox => {
     checkbox.addEventListener('change', (e) => {
@@ -16,7 +15,6 @@ function setupCheckboxEventListeners() {
 
       const url = `/shopping_lists/${listId}/toggle_check`;
 
-      console.log(url);
       fetch(url, {
         method: 'POST',
         headers: {
@@ -26,7 +24,11 @@ function setupCheckboxEventListeners() {
         },
         body: JSON.stringify({ is_checked: isChecked })
       })
-      .then(response => response.json())
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+      })
     });
   });
 }


### PR DESCRIPTION
目的：
献立リストの買い物完了ボタンに関するユーザーインターフェースを改善することが目的です。

内容：
・ボタンが無効状態の時、マウスオーバー/アウトイベントによる背景色の変更が行われないように修正
・ボタンが有効状態の時のみ、マウスオーバー/アウトイベントを追加し、背景色の変更を行うように修正
・app/javascript/shopping_list_checkbox_handlers.jsのコードエラーが原因の１つにあったため、こちらも一部修正

備考：
チェックボックスをすべてtureにしてから一度ページを離脱し、再度リストへ戻ると「買い物完了ボタンが無効状態」になっていました。これを改善するために今回の修正を行いました。

・ボタン有効時
<img width="513" alt="スクリーンショット 2023-12-14 23 57 53" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/22ad9e00-cae6-443a-b1c9-94601187d2da">
・ボタン無効時
<img width="526" alt="スクリーンショット 2023-12-14 23 57 46" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/0a15dc18-1d51-4d76-af9d-03a0782fe041">
