### PR TITLE
買い物完了時のCompletedMenu登録と買い物リスト削除するcreateアクションを実装

### DIFF
--- a/app/controllers/completed_menus_controller.rb
+++ b/app/controllers/completed_menus_controller.rb
@@ -1,10 +1,5 @@
 class CompletedMenusController < ApplicationController
 
-  def index
-    # 買い出しが完了した食材データを取得
-    @completed_menus = CompletedMenu.where(user_id: current_user.id)
-  end
-
   def create
     # 現在のユーザーのShoppingListMenuからデータを取得
     shopping_list = current_user.cart.shopping_list

--- a/app/controllers/completed_menus_controller.rb
+++ b/app/controllers/completed_menus_controller.rb
@@ -1,2 +1,41 @@
 class CompletedMenusController < ApplicationController
+
+  def index
+    # 買い出しが完了した食材データを取得
+    @completed_menus = CompletedMenu.where(user_id: current_user.id)
+  end
+
+  def create
+    # 現在のユーザーのShoppingListMenuからデータを取得
+    shopping_list = current_user.cart.shopping_list
+
+    # 現在登録されている買い物リストデータ
+    shopping_list_menus = ShoppingListMenu.where(shopping_list_id: shopping_list.id)
+    shopping_list_items = shopping_list.shopping_list_items
+
+    begin
+      ActiveRecord::Base.transaction do
+
+        # completed_menusデータを作成
+        shopping_list_menus.each do |menu|
+          current_user.completed_menus.create!(
+            user_id: current_user.id,
+            menu_id: menu.menu_id,
+            menu_count: menu.menu_count,
+            is_completed: false,
+          )
+        end
+
+        # 買い物リストのデータ削除
+        shopping_list_menus.delete_all
+        shopping_list_items.delete_all
+      end
+    rescue ActiveRecord::RecordInvalid
+      handle_general_error
+      return
+    end
+
+    redirect_to completed_menus_path
+  end
+
 end

--- a/app/views/completed_menus/index.html.erb
+++ b/app/views/completed_menus/index.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @completed_menus %></h1>

--- a/app/views/completed_menus/index.html.erb
+++ b/app/views/completed_menus/index.html.erb
@@ -1,1 +1,0 @@
-<h1><%= @completed_menus %></h1>

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -65,7 +65,7 @@
 
     <div class="button-container">
       <div class="shopping-complete-button">
-        <%= button_to '買い物完了', root_path, method: :get, class: 'complete-button', id: 'complete-button' %>
+        <%= button_to '買い物完了', completed_menus_path, method: :post, class: 'complete-button', id: 'complete-button' %>
       </div>
       <%= button_to '戻る', '#', method: :get, class: 'back-button', id: 'back_button', onclick: "history.back(); return false;" %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
 
   post '/shopping_lists/:id/toggle_check', to: 'shopping_lists#toggle_check', as: 'shopping_list_toggle_check'
 
+  resources :completed_menus
+
   devise_for :users
   devise_scope :user do
     get 'users/registration', to: 'custom_registrations#new', as: :new_user_custom_registration

--- a/db/migrate/20231215010902_create_completed_menus.rb
+++ b/db/migrate/20231215010902_create_completed_menus.rb
@@ -5,7 +5,7 @@ class CreateCompletedMenus < ActiveRecord::Migration[7.0]
       t.references :menu,             null: false, foreign_key: true
       t.integer :menu_count,          null: false
       t.boolean :is_completed,        null: false, default: false
-      t.date :date_completed,         null: false
+      t.date :date_completed
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_15_010902) do
     t.bigint "menu_id", null: false
     t.integer "menu_count", null: false
     t.boolean "is_completed", default: false, null: false
-    t.date "date_completed", null: false
+    t.date "date_completed"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["menu_id"], name: "index_completed_menus_on_menu_id"


### PR DESCRIPTION
目的：
買い物完了時にユーザーのショッピングリストからCompletedMenuへのデータ移行と、使用済みの買い物リストデータの削除することが目的です。

内容：
・CompletedMenusController に create アクションを追加し、買い物完了時に CompletedMenu モデルへのデータ登録を行う処理を実装
・買い物リストから CompletedMenu へデータが移行された後、元の買い物リストを削除する処理を追加
・トランザクションを使用して、これらの処理を原子的に行い、データの整合性を保持

