### PR TITLE
“CompletedMenusControllerのindexアクション追加、対応ビューとメニューバー項目の実装“

### DIFF
--- a/app/assets/stylesheets/completed_menu.scss
+++ b/app/assets/stylesheets/completed_menu.scss
@@ -1,0 +1,56 @@
+@import 'shared/styles';
+
+.completed-menu-container{
+  @include menu-index;
+
+
+  .completed-menu-heading {
+    @include menu-heading;
+    @include menu-heading-after;
+  }
+
+  .completed-menu-heading h3 {
+    margin-bottom: 0px;
+  }
+
+  .completed-menus_list{
+    @include menus-list;
+    margin-bottom: 40px;
+
+    .completed-menu-item{
+      @include menu-item;
+      @include hover-background(#e6e6e6);
+      height: 320px;
+      cursor: pointer;
+
+      .completed-menu-date {
+        font-size: 12px;
+        color: rgba(0, 0, 0, 0.6);
+        width: 100%;
+      }
+
+      .completed-menu-date p {
+        margin-top: 0px;
+        margin-bottom: 0px;
+      }
+
+      .rounded-image{
+        @include rounded-image;
+      }
+
+      .completed-menu-item-title{
+        @include menu-item-title;
+        font-size: 20px;
+      }
+
+      .completed-menu-count{
+        .menu-item-quantity {
+          width: 100%;
+          padding-top: 7px;
+        }
+      }
+
+    }
+
+  }
+}

--- a/app/assets/stylesheets/menu-bar.scss
+++ b/app/assets/stylesheets/menu-bar.scss
@@ -53,7 +53,7 @@
     }
 
     // リンクテキストのスタイル
-    @media screen and (max-width: 900px){
+    @media screen and (max-width: 1100px){
       .menu-link {
         display: none;
       }
@@ -65,7 +65,7 @@
 .mobile-menu-botton{
   display: none;
 
-  @media screen and (max-width: 900px) {
+  @media screen and (max-width: 1100px) {
     display: block;
 
     // ハンバーガーメニューのボタンスタイル

--- a/app/assets/stylesheets/shared/_styles.scss
+++ b/app/assets/stylesheets/shared/_styles.scss
@@ -166,19 +166,6 @@
   }
 }
 
-@mixin menu-heading{
-  display: block;
-  margin-top: 50px;
-  font-size: 30px;
-  position: relative;
-  display: inline-block;
-  padding-bottom: 5px;
-  @media screen and (max-width: 460px) {
-    display: inline-block;
-    font-size: 20px;
-  }
-}
-
 @mixin menu-heading-after {
   &::after {
     content: "";
@@ -195,4 +182,53 @@
   &:hover {
     background-color: $color;
   }
+}
+
+@mixin menu-index{
+  text-align: center;
+  width: 100%;
+  justify-content: center;
+}
+
+@mixin menu-heading-h3{
+  margin-bottom: 0;
+  padding-bottom: 5px;
+  line-height: 1.2;
+}
+
+@mixin menus-list{
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  gap: 10px;
+  align-items: stretch;
+  justify-content: center;
+  padding-top: 30px;
+}
+
+@mixin menu-item-title {
+  margin-top: 10px;
+  color: black;
+  text-decoration: none;
+}
+
+@mixin menu-item{
+  position: relative;
+  width: 250px;
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: #f8f8f8;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border-radius: 8px;
+  border-radius: 20px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+}
+
+@mixin rounded-image{
+  border-radius: 20px;
 }

--- a/app/assets/stylesheets/user-index.scss
+++ b/app/assets/stylesheets/user-index.scss
@@ -1,9 +1,7 @@
 @import 'shared/styles';
 
 .menu-index-container{
-  text-align: center;
-  width: 100%;
-  justify-content: center;
+  @include menu-index;
 
   .menu-heading {
     @include menu-heading;
@@ -11,44 +9,21 @@
   }
 
   .menu-heading h3 {
-    margin-bottom: 0;
-    padding-bottom: 5px;
-    line-height: 1.2;
+    @include menu-heading-h3;
   }
 
   .menus_list{
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around;
-    gap: 10px;
-    align-items: stretch;
-    justify-content: center;
-    padding-top: 30px;
+    @include menus_list;
 
     .menu-item{
-      position: relative;
-      width: 250px;
-      height: 300px;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      background-color: #f8f8f8;
-      border: 1px solid #ddd;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-      border-radius: 8px;
-      border-radius: 20px;
-      margin-right: 10px;
-      margin-bottom: 10px;
+      @include menu_item;
 
       .rounded-image {
-        border-radius: 20px;
+        @include rounded-image;
       }
 
       .menu-item-title {
-        margin-top: 10px;
-        color: black;
-        text-decoration: none;
+        @include menu-item-title;
       }
 
       .delete-button {
@@ -128,7 +103,7 @@
 
     .bg-standard-menu {
       background-color: #777;
-      @include hover-background;
+      @include hover-background(#dadada);
     }
 
     .bg-shopping-list {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include Devise::Controllers::Helpers
   before_action :load_settings
   before_action :check_shopping_list_menu_items
+  before_action :check_completed_menus_date
 
   private
 
@@ -24,6 +25,12 @@ class ApplicationController < ActionController::Base
     else
       @has_menu_items = false
     end
+  end
+
+  # 作れる献立がある場合にメニューバーへ「献立を選ぶ」「献立を作る」の選択肢を追加するために設定
+  def check_completed_menus_date
+    completed_menus = CompletedMenu.where(user_id: current_user.id)
+    @completed_menus_date = completed_menus.exists?
   end
 
   def handle_general_error

--- a/app/controllers/completed_menus_controller.rb
+++ b/app/controllers/completed_menus_controller.rb
@@ -1,5 +1,14 @@
 class CompletedMenusController < ApplicationController
 
+  def index
+    # 買い出しが完了した食材データを取得
+    @completed_menus = CompletedMenu.where(user_id: current_user.id)
+
+    # 買い物完了したメニューがない場合、献立選択画面にリダイレクト
+    redirect_to root_path if @completed_menus.empty?
+  end
+
+
   def create
     # 現在のユーザーのShoppingListMenuからデータを取得
     shopping_list = current_user.cart.shopping_list

--- a/app/views/completed_menus/index.html.erb
+++ b/app/views/completed_menus/index.html.erb
@@ -1,0 +1,28 @@
+<%= render 'shared/menu' %>
+
+<div class="completed-menu-container">
+
+  <div class="completed-menu-heading">
+    <h3>作れる献立</h3>
+  </div>
+
+  <div class="completed-menus_list">
+    <% @completed_menus.each do |item| %>
+      <div class="completed-menu-item">
+
+        <%= image_tag(rails_blob_path(item.menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+
+        <div class="completed-menu-date">
+          <p>買出し日：<%= item.created_at.strftime('%Y/%m/%d') %></p>
+        </div>
+
+        <div class="completed-menu-item-title"><%= truncate(item.menu.menu_name, length: 10, omission: '..') %></div>
+
+        <div class="completed-menu-count">
+          <div class="menu-item-quantity"><%= item.menu_count %>人分</div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -5,9 +5,19 @@
   </div>
   <div class="menu-bar-right">
     <div id="menu" class="desktop-menu">
+
+      <% if @completed_menus_date %>
+        <%= link_to "献立を選ぶ", root_path, class: "menu-link" %>
+      <% end %>
+
       <% if @has_menu_items %>
         <%= link_to "買い物リスト", shopping_lists_path, class: "menu-link" %>
       <% end %>
+
+      <% if @completed_menus_date %>
+        <%= link_to "献立を作る", completed_menus_path, class: "menu-link" %>
+      <% end %>
+
       <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "menu-link" %>
       <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "menu-link" %>
       <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "menu-link" %>
@@ -23,9 +33,18 @@
 </div>
 
 <div class="mobile-menu-content">
+  <% if @completed_menus_date %>
+    <%= link_to "献立を選ぶ", root_path, class: "mobile-menu-link" %>
+  <% end %>
+
   <% if @has_menu_items %>
     <%= link_to "買い物リスト", shopping_lists_path, class: "mobile-menu-link" %>
   <% end %>
+
+  <% if @completed_menus_date %>
+    <%= link_to "献立を作る", completed_menus_path, class: "mobile-menu-link" %>
+  <% end %>
+
   <%= link_to "カレンダー", user_my_page_path(current_user.id), class: "mobile-menu-link" %>
   <%= link_to "ユーザー情報", edit_user_custom_registration_path(current_user.id), class: "mobile-menu-link" %>
   <%= link_to "ログアウト", destroy_user_custom_session_path, method: :get, class: "mobile-menu-link" %>


### PR DESCRIPTION
目的：
ユーザーが完了したメニューを一覧で表示できるように設定することで、買い物完了後のメニュー管理を容易に管理できるようにすることが目的です。

内容：
・CompletedMenusControllerに新しいindexアクションを追加
・ユーザーが完了したメニューを表示するビュー（index.html.erb）を実装
・買い物を完了したメニューがない場合にroot_pathへリダイレクトするように設定
・買い物を完了したメニューがある場合にはメニューバーに「献立を選ぶ」と「献立を作る」のナビゲーションリンクを追加

・PC画面
<img width="1419" alt="スクリーンショット 2023-12-15 21 58 38" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/07c109c1-ae89-49d4-bc8d-e4a142e5f57f">
・画面縮小のハンバーガーメニュー
<img width="294" alt="スクリーンショット 2023-12-15 21 59 05" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/acae733e-4347-4738-8193-766cad611d6a">

