### PR TITLE
“献立の総数計算メソッドの実装と登録上限チェックの追加“

### DIFF
--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -4,6 +4,16 @@ class CartItemsController < ApplicationController
     # 現在のユーザーのカートを取得または新規作成
     cart = current_user.cart || current_user.create_cart
 
+    # 各モデルからのアイテム数の総計を取得
+    total_items_count = total_items_count(cart)
+    max_total_items = @settings.dig('limits', 'max_total_items')
+
+    # 総数が20個を超えている場合の処理
+    if total_items_count >= max_total_items
+      flash[:error] = "献立の登録上限に達しました。"
+      redirect_back(fallback_location: root_path) and return
+    end
+
     # カート内の同じmenu_idのアイテムを検索
     cart_item = cart.cart_items.find_by(menu_id: params[:menu_id])
 
@@ -40,5 +50,23 @@ class CartItemsController < ApplicationController
     cart_item = CartItem.find_by(id: params[:id])
     cart_item.decrement!(:item_count) if cart_item.item_count > 1
     redirect_back(fallback_location: root_path)
+  end
+
+  private
+
+  # このメソッドは、ユーザーが関連するCompletedMenu、ShoppingListMenu、
+  # およびCartItemモデルからの総アイテム数を計算します。
+  def total_items_count(cart)
+    # ユーザーに関連するCompletedMenuモデルのアイテム数を計算
+    completed_menus_count = CompletedMenu.where(user_id: current_user.id).count
+
+    # ユーザーのカートに関連するShoppingListMenuモデルのアイテム数を計算
+    shopping_list_menus_count = ShoppingListMenu.where(shopping_list_id: cart.shopping_list&.id).count
+
+    # カート内のCartItemモデルのアイテム数を計算
+    cart_items_count = cart.cart_items.count
+
+    # 3つのモデルからの総アイテム数を合計して返す
+    completed_menus_count + shopping_list_menus_count + cart_items_count
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,6 @@ pagination:
 
 ingredient:
   no_quantity_unit_id: 17
+
+limits:
+  max_total_items: 20


### PR DESCRIPTION
目的：
ユーザーがアプリケーション内で行う献立の登録数の上限を設定し、ユーザーが設定を超える数の献立を登録することを防ぐことが目的です。

内容：
・CartItemsControllerにtotal_items_count メソッドを実装し、ユーザーに関連する CompletedMenu、ShoppingListMenu、CartItem モデルから総アイテム数を計算する機能を実装
・計算した総アイテム数が設定された上限（20）を超えた場合にユーザーにエラーメッセージを表示し、前のページにリダイレクトする処理を追加

備考：
献立の登録上限を20個に設定したのは、実際の生活リズムと食事計画を考慮しています。この数値は、週に1回の買い物で十分な量を購入でき、同時に日々の食事の多様性や外食の機会も考慮に入れています。1種類の献立に複数人前を含めることが可能であり、これにより実際の食事数が20回を少し下回ることも考慮されています。この設定で無駄な買い物を防ぎつつ、柔軟な食事計画を可能になると思います。

・エラーメッセージ
<img width="1422" alt="スクリーンショット 2023-12-15 23 34 45" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/af462adc-fd2a-40ab-a8db-edd93284d14d">
