### PR TITLE
買い物完了した献立の詳細画面で、「人数に応じた食材量の表示変更機能」と「調理完了確認ダイヤログ表示機能」を実装

### DIFF
--- a/app/assets/stylesheets/completed_menu/completed_menu_show.scss
+++ b/app/assets/stylesheets/completed_menu/completed_menu_show.scss
@@ -7,12 +7,121 @@
     width: 100%;
   }
 
-  .button-container{
-    width: 100%;
-    .back-button{
-      @include button;
-      width: 45%;
+  .menu-detail-container{
+    width: 70%;
+    @media screen and (max-width: 600px) {
+      width: 100%;
+    }
+
+    .ingredient-show-container{
+      @include flex-center-column;
+      @media screen and (max-width: 480px) {
+        width: 100%;
+      }
+
+      .show-contents-title{
+        @include contents-title;
+        margin-top: 30px;
+      }
+
+      #ingredients_list {
+        width: 100%;
+
+        .show-contents-container{
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin: auto;
+          width: 100%;
+          height: 40px;
+          margin-bottom: 40px;
+
+          .serving-size-display{
+            text-align:  center;
+            margin-top: 27px;
+            margin-bottom: 30px;
+            margin-left: 60px;
+            margin-right: 60px;
+            font-size: 18px;
+          }
+
+          .serving-size-display p{
+            margin-top: 20px;
+          }
+
+          .serving-adjust-button {
+            background: none;
+            font-size: 28px;
+            border: none;
+            cursor: pointer;
+            @include hover-background;
+          }
+        }
+      }
+
+      .ingredients-show-list {
+        width: 60%;
+        padding-bottom: 30px;
+        margin: auto;
+        @media screen and (max-width: 1400px) {
+          width: 95%;
+        }
+  
+        .ingredient-show-item {
+          display: flex;
+          justify-content: space-between;
+          align-items: baseline;
+          border-bottom: 1px solid black;
+          padding-bottom: 5px;
+          margin-bottom: 5px;
+        }
+  
+        .ingredient-show-item p {
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+  
+        .material-name {
+          flex-basis: 70%;
+        }
+  
+        .quantity-unit {
+          display: flex;
+          flex-basis: 30%;
+          justify-content: flex-end;
+        }
+  
+        .quantity,
+        .unit {
+          margin-left: 10px;
+        }
+  
+        .no-ingredients {
+          text-align: center
+        }
+      }
     }
   }
 
+  .button-container{
+    width: 100%;
+
+    .complete-cooking-button,
+    .back-button{
+      @include button;
+      width: 70%;
+    }
+
+    .complete-cooking-button{
+      height: 60px;
+      margin-top: 20px;
+      margin-bottom: 5px;
+      background-color: #555
+    }
+
+    .back-button{
+      margin-top: 15px;
+      margin-bottom: 10px;
+    }
+  }
 }

--- a/app/assets/stylesheets/menu/menu_show.scss
+++ b/app/assets/stylesheets/menu/menu_show.scss
@@ -7,6 +7,68 @@
     width: 100%;
   }
 
+  .menu-detail-container{
+    width: 70%;
+    @media screen and (max-width: 600px) {
+      width: 100%;
+    }
+
+    .ingredient-show-container{
+      @include flex-center-column;
+      @media screen and (max-width: 480px) {
+        width: 100%;
+      }
+
+      .show-contents-title p{
+        @include contents-title;
+        margin-bottom: 30px;
+      }
+
+
+      .ingredients-show-list {
+        width: 60%;
+        padding-bottom: 30px;
+        @media screen and (max-width: 1400px) {
+          width: 95%;
+        }
+  
+        .ingredient-show-item {
+          display: flex;
+          justify-content: space-between;
+          align-items: baseline;
+          border-bottom: 1px solid black;
+          padding-bottom: 5px;
+          margin-bottom: 5px;
+        }
+  
+        .ingredient-show-item p {
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+  
+        .material-name {
+          flex-basis: 70%;
+        }
+  
+        .quantity-unit {
+          display: flex;
+          flex-basis: 30%;
+          justify-content: flex-end;
+        }
+  
+        .quantity,
+        .unit {
+          margin-left: 10px;
+        }
+  
+        .no-ingredients {
+          text-align: center
+        }
+      }
+
+    }
+  }
+
   .menu-button-container {
     width: 100%;
 

--- a/app/assets/stylesheets/menu_details.scss
+++ b/app/assets/stylesheets/menu_details.scss
@@ -1,68 +1,8 @@
 @import 'shared/menuForm';
 
-.menu-detail-container{
-  width: 70%;
-  @media screen and (max-width: 600px) {
-    width: 100%;
-  }
-
-  .menu-show-list{
-    @include flex-center-column;
-    .show-contents-title{
-      @include contents-title;
-    }
-  }
-
-  .ingredient-show-container{
-    @include flex-center-column;
-    @media screen and (max-width: 480px) {
-      width: 100%;
-    }
-
-    .show-contents-title{
-      @include contents-title;
-      margin-bottom: 30px;
-    }
-
-    .ingredients-show-list {
-      width: 60%;
-      padding-bottom: 30px;
-      @media screen and (max-width: 1400px) {
-        width: 95%;
-      }
-
-      .ingredient-show-item {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        border-bottom: 1px solid black;
-        padding-bottom: 5px;
-        margin-bottom: 5px;
-      }
-
-      .ingredient-show-item p {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .material-name {
-        flex-basis: 70%;
-      }
-
-      .quantity-unit {
-        display: flex;
-        flex-basis: 30%;
-        justify-content: flex-end;
-      }
-
-      .quantity,
-      .unit {
-        margin-left: 10px;
-      }
-
-      .no-ingredients {
-        text-align: center
-      }
-    }
+.menu-show-list{
+  @include flex-center-column;
+  .show-contents-title{
+    @include contents-title;
   }
 }

--- a/app/javascript/confirm_complete_menu.js
+++ b/app/javascript/confirm_complete_menu.js
@@ -1,0 +1,25 @@
+confirmCompleteCooking()
+
+function confirmCompleteCooking() {
+  // 'complete-cooking-button' IDを持つ要素を取得
+  const completeCookingButton = document.getElementById('complete-cooking-button');
+
+  // ボタンが存在しない場合は関数を早期に終了
+  if (!completeCookingButton) return;
+
+  // ボタンのクリックイベントに対するリスナーを設定
+  completeCookingButton.addEventListener('click', (e) => {
+    e.preventDefault();
+
+    // ボタンのデータ属性からURLを取得
+    const url = completeCookingButton.getAttribute('data-url');
+
+    // 確認ダイアログのメッセージを構築
+    const confirmationMessage = "本当に" + completeCookingButton.textContent.trim() + "を調理完了してよろしいですか？";
+
+    // 確認ダイアログを表示し、OKが押された場合のみURLに遷移
+    if (confirm(confirmationMessage)) {
+      window.location.href = url;
+    }
+  });
+}

--- a/app/views/completed_menus/index.html.erb
+++ b/app/views/completed_menus/index.html.erb
@@ -10,7 +10,7 @@
     <% @completed_menus.each do |item| %>
       <% @completed_menus.each do |item| %>
         <div class="completed-menu-item">
-          <%= link_to completed_menu_path(item, menu_id: item.menu_id, menu_count: item.menu_count) do %>
+          <%= link_to completed_menu_path(item, menu_id: item.menu_id, serving_size: item.menu_count, max_count: item.menu_count) do %>
             <%= image_tag(rails_blob_path(item.menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
 
             <div class="completed-menu-date">

--- a/app/views/completed_menus/show.html.erb
+++ b/app/views/completed_menus/show.html.erb
@@ -1,9 +1,55 @@
 
 <div class="completed-show-container">
 
-  <%= render partial: 'shared/menu_details', locals: { menu: @menu, ingredients: @scaled_ingredients, serving_size: @serving_size } %>
+  <div class="menu-detail-container">
+    <%= render partial: 'shared/menu_details', locals: { menu: @menu } %>
 
-  <div class="button-container">
-    <%= button_to '戻る', completed_menus_path, method: :get, class: 'back-button', id: 'back_button' %>
+    <div class="ingredient-show-container">
+      <div class="show-contents-title">
+        <p>食材リスト</p>
+      </div>
+
+      <%= turbo_frame_tag 'ingredients_list' do %>
+        <div class="show-contents-container">
+          <div class="serving-adjust-button">
+            <%= button_to '◀', decrease_completed_menu_path(@menu, serving_size: @serving_size, max_count: @max_serving_size), method: :post, class: 'serving-adjust-button', data: { turbo_frame: 'ingredients_list' } %>
+          </div>
+
+          <div class="serving-size-display">
+            <p><%= @serving_size.presence || 1 %>人前</p>
+          </div>
+
+          <div class="serving-adjust-button">
+            <%= button_to '▶︎', increase_completed_menu_path(@menu, serving_size: @serving_size, max_count: @max_serving_size), method: :post, class: 'serving-adjust-button', data: { turbo_frame: 'ingredients_list' } %>
+          </div>
+        </div>
+
+        <div class="ingredients-show-list">
+          <% if @scaled_ingredients.present? %>
+            <% @scaled_ingredients.each do |ingredient_date| %>
+              <div class="ingredient-show-item">
+                <p class="material-name"><%= ingredient_date.material.material_name %></p>
+                <div class="quantity-unit">
+                  <p class="quantity"><%= display_quantity(ingredient_date.quantity) %></p>
+                  <p class="unit"><%= ingredient_date.unit.unit_name %></p>
+                </div>
+              </div>
+            <% end %>
+          <% else %>
+            <p class="no-ingredients">食材はありません</p>
+          <% end %>
+        </div>
+
+        <div class="button-container">
+          <%= button_to "#{@serving_size}人前を調理完了", "#", method: :get, class: 'complete-cooking-button', id: 'complete-cooking-button', data: { turbo: false }, "data-url": root_path %>
+        </div>
+
+        <%= javascript_include_tag 'confirm_complete_menu' %>
+      <% end %>
+    </div>
+
+    <div class="button-container">
+      <%= button_to '戻る', completed_menus_path, method: :get, class: 'back-button' %>
+    </div>
   </div>
 </div>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -1,6 +1,30 @@
 
 <div class="menu-show-container">
-  <%= render partial: 'shared/menu_details', locals: { menu: @menu, ingredients: @aggregated_ingredients, serving_size: nil } %>
+  <div class="menu-detail-container">
+    <%= render partial: 'shared/menu_details', locals: { menu: @menu } %>
+
+    <div class="ingredient-show-container">
+      <div class ="show-contents-title">
+        <p>食材リスト</p>
+      </div>
+
+      <div class="ingredients-show-list">
+        <% if @aggregated_ingredients.present? %>
+          <% @aggregated_ingredients.each do |ingredient_date| %>
+            <div class="ingredient-show-item">
+              <p class="material-name"><%= ingredient_date.material.material_name %></p>
+              <div class="quantity-unit">
+                <p class="quantity"><%= display_quantity(ingredient_date.quantity) %></p>
+                <p class="unit"><%= ingredient_date.unit.unit_name %></p>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <p class="no-ingredients">食材はありません</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
 
   <div class="menu-button-container">
     <%= form_with url: cart_items_path, method: :post do |form| %>

--- a/app/views/shared/_menu_details.html.erb
+++ b/app/views/shared/_menu_details.html.erb
@@ -1,59 +1,36 @@
-<div class="menu-detail-container">
-  <div class="menu-show-list">
-    <div class="menu-show-title">
-      <h1>献立情報</h1>
-    </div>
 
-    <div class="show-contents-title">
-      <p>　献立名　</p>
-    </div>
-
-    <div class="menu-contents">
-      <%= menu.menu_name %>
-    </div>
-
-    <div class="show-contents-title">
-      <p>　献立内容　</p>
-    </div>
-    <div class ="menu-contents">
-      <%= menu.menu_contents %>
-    </div>
-
-    <div class="show-contents-title">
-      <p>　作り方　</p>
-    </div>
-    <div class="menu-contents">
-      <%= simple_format(sanitize(menu.contents)) %>
-    </div>
-
-    <div class="show-contents-title">
-      <p>　献立画像　</p>
-    </div>
-
-    <div class ="menu-contents">
-      <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
-    </div>
+<div class="menu-show-list">
+  <div class="menu-show-title">
+    <h1>献立情報</h1>
   </div>
 
-  <div class="ingredient-show-container">
-    <div class ="show-contents-title">
-      <p>食材リスト（<%= serving_size.presence || 1 %>人分）</p>
-    </div>
+  <div class="show-contents-title">
+    <p>　献立名　</p>
+  </div>
 
-    <div class="ingredients-show-list">
-      <% if ingredients.present? %>
-        <% ingredients.each do |ingredient_date| %>
-          <div class="ingredient-show-item">
-            <p class="material-name"><%= ingredient_date.material.material_name %></p>
-            <div class="quantity-unit">
-              <p class="quantity"><%= display_quantity(ingredient_date.quantity) %></p>
-              <p class="unit"><%= ingredient_date.unit.unit_name %></p>
-            </div>
-          </div>
-        <% end %>
-      <% else %>
-        <p class="no-ingredients">食材はありません</p>
-      <% end %>
-    </div>
+  <div class="menu-contents">
+    <%= menu.menu_name %>
+  </div>
+
+  <div class="show-contents-title">
+    <p>　献立内容　</p>
+  </div>
+  <div class ="menu-contents">
+    <%= menu.menu_contents %>
+  </div>
+
+  <div class="show-contents-title">
+    <p>　作り方　</p>
+  </div>
+  <div class="menu-contents">
+    <%= simple_format(sanitize(menu.contents)) %>
+  </div>
+
+  <div class="show-contents-title">
+    <p>　献立画像　</p>
+  </div>
+
+  <div class ="menu-contents">
+    <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,12 @@ Rails.application.routes.draw do
 
   post '/shopping_lists/:id/toggle_check', to: 'shopping_lists#toggle_check', as: 'shopping_list_toggle_check'
 
-  resources :completed_menus
+  resources :completed_menus do
+    member do
+      post 'increase_serving', to: 'completed_menus#increase_serving', as: :increase
+      post 'decrease_serving', to: 'completed_menus#decrease_serving', as: :decrease
+    end
+  end
 
   devise_for :users
   devise_scope :user do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,3 +8,4 @@ ingredient:
 
 limits:
   max_total_items: 20
+  min_serving_size: 1


### PR DESCRIPTION
目的：
買い物を完了した献立の使い勝手を向上させることがこのプルリクエストの主な目的です。ユーザーが献立を作成する際に、実際の調理に必要な食材の量を柔軟に調整できるようにすることで、ユーザーの利便性と満足度を高めることを目指しています。

内容：
・CompletedMenusモデルの詳細画面に、ユーザーが選択した人数に基づいて食材の量を動的に表示する機能を実装
・「increase_serving」と「decrease_serving」の2つのアクションを追加し、サービングサイズの動的調整を設定
・サービングサイズの設定と最大サービングサイズの設定を行うため、before_action :set_serving_size と before_action :set_max_serving_size を show、increase_serving、decrease_serving アクションに適用
・機能追加に伴い _menu_details.html.erb パーシャルの内容を調整し、必要な部分を元のファイルに移動
・調理完了の際に表示される確認ダイアログ機能を追加し、ユーザーが誤って操作をしないように設定
・確認ダイアログ機能はJavaScriptを使用して、調理完了時にユーザーに確認を求めるダイアログを表示する機能を実装

・作成人変更ボタンと完了ボタン
<img width="927" alt="スクリーンショット 2023-12-16 22 56 16" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/cf19327d-252b-4c36-906c-4076c27686cd">
<img width="966" alt="スクリーンショット 2023-12-16 22 56 24" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/88d54881-dd17-4078-9785-83c2e43de7ae">
・確認ダイヤログ
<img width="489" alt="スクリーンショット 2023-12-16 22 57 02" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/93d542a5-422a-498b-bd34-5ec2d39c6b0f">

