### PR TITLE
調理後の処理を実装、献立数を調整する機能のメソッド・アクション統合、関連コード一部修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
 
   # 作れる献立がある場合にメニューバーへ「献立を選ぶ」「献立を作る」の選択肢を追加するために設定
   def check_completed_menus_date
-    completed_menus = CompletedMenu.where(user_id: current_user.id)
+    completed_menus = CompletedMenu.where(user_id: current_user.id, is_completed: false)
     @completed_menus_date = completed_menus.exists?
   end
 

--- a/app/controllers/completed_menus_controller.rb
+++ b/app/controllers/completed_menus_controller.rb
@@ -109,7 +109,7 @@ class CompletedMenusController < ApplicationController
       menu_to_update.update!(is_completed: true, date_completed: Time.current)
     end
 
-    flash[:notice] = "献立の調理が完了しました。"
+    flash[:notice] = "献立の調理完了です。お疲れ様でした！"
     redirect_to completed_menus_path
   end
 

--- a/app/controllers/completed_menus_controller.rb
+++ b/app/controllers/completed_menus_controller.rb
@@ -1,11 +1,10 @@
 class CompletedMenusController < ApplicationController
   include IngredientsAggregator
-  before_action :set_serving_size, only: [:show, :increase_serving, :decrease_serving]
-  before_action :set_max_serving_size, only: [:show, :increase_serving, :decrease_serving]
+  before_action :set_serving_sizes, only: [:show, :change_serving_size]
 
   def index
     # 買い出しが完了した食材データを取得
-    @completed_menus = CompletedMenu.where(user_id: current_user.id)
+    @completed_menus = CompletedMenu.where(user_id: current_user.id, is_completed: false)
 
     # 買い物完了したメニューがない場合、献立選択画面にリダイレクト
     redirect_to root_path if @completed_menus.empty?
@@ -52,7 +51,6 @@ class CompletedMenusController < ApplicationController
     # 重複した献立を基準の単位に変換し、合算する
     menu_ingredients = MenuIngredient.where(menu_id: @menu.id)
     ingredients = menu_ingredients.includes(:ingredient).map(&:ingredient)
-
     aggregated_ingredients = aggregate_ingredients(ingredients)
 
     # scale_ingredientsメソッドを呼び出して、quantityを更新
@@ -60,18 +58,61 @@ class CompletedMenusController < ApplicationController
   end
 
 
-  def increase_serving
+  def change_serving_size
+    # increase_servingと同様の理由
     menu_id = params[:id]
-    @serving_size = [@serving_size + 1, @max_serving_size].min
+    # 減少か増加をするかどうかを判断
+    change_type = params[:change_type]
+    # 献立の最低数でこれ以上は現状できない数値
+    min_serving_size = @settings.dig('limits', 'min_serving_size')
+
+    if change_type == 'increase'
+      # 調理する献立の数量を増加
+      @serving_size = [@serving_size + 1, @max_serving_size].min
+    elsif change_type == 'decrease'
+      # 調理する献立の数量を現状
+      @serving_size = [@serving_size - 1, min_serving_size].max
+    end
+
     redirect_to completed_menu_path(menu_id: menu_id, serving_size: @serving_size, max_count: @max_serving_size)
   end
 
-  def decrease_serving
-    menu_id = params[:id]
-    min_serving_size = @settings.dig('limits', 'min_serving_size')
-    @serving_size = [@serving_size - 1, min_serving_size].max
-    redirect_to completed_menu_path(menu_id: menu_id, serving_size: @serving_size, max_count: @max_serving_size)
+
+  def mark_as_completed
+    # ActiveRecord::Relationオブジェクトのため「first」でデータを取得
+    menu_to_update = CompletedMenu.find_by(menu_id: params[:menu_id], user_id: current_user.id, is_completed: false)
+
+    # 作った献立の数を取得
+    serving_size = params[:serving_size].to_i
+
+    # 買い出しした献立数を変数に格納
+    purchased_menu_count = menu_to_update.menu_count
+
+    # 「買い出しした献立数」より「作った献立」が少ない場合の処理
+    if serving_size < purchased_menu_count
+      begin
+        ActiveRecord::Base.transaction do
+          # 新しい数量でレコードを複製
+          completed_menu = menu_to_update.dup
+          # データを作った献立データとして再設定
+          completed_menu.update!(menu_count: serving_size, is_completed: true, date_completed: Time.current)
+          # 元のレコードを新しい数量を引いた値で更新
+          menu_to_update.update!(menu_count: purchased_menu_count - serving_size)
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        handle_general_error(e)
+        return
+      end
+
+    else
+      # 「買い出しした献立数」と「作った献立」が同じ場合の処理
+      menu_to_update.update!(is_completed: true, date_completed: Time.current)
+    end
+
+    flash[:notice] = "献立の調理が完了しました。"
+    redirect_to completed_menus_path
   end
+
 
   private
 
@@ -90,11 +131,13 @@ class CompletedMenusController < ApplicationController
     end
   end
 
-  def set_serving_size
-    @serving_size = params[:serving_size].to_i
-  end
 
-  def set_max_serving_size
+  # show, increase_serving, decrease_servingアクションで利用。
+  # before_actionで設定され、繰り返しのコードを避けるためにメソッド化。
+  def set_serving_sizes
+    # 調理する献立の数量
+    @serving_size = params[:serving_size].to_i
+    # 調理する献立最大数量
     @max_serving_size = params[:max_count].to_i
   end
 

--- a/app/javascript/confirm_complete_menu.js
+++ b/app/javascript/confirm_complete_menu.js
@@ -14,8 +14,6 @@ function confirmCompleteCooking() {
     // ボタンのデータ属性からURLを取得
     const url = completeCookingButton.getAttribute('data-url');
 
-    console.log(url);
-
     // 確認ダイアログのメッセージを構築
     const confirmationMessage = "本当に" + completeCookingButton.textContent.trim() + "を調理完了してよろしいですか？";
 

--- a/app/javascript/confirm_complete_menu.js
+++ b/app/javascript/confirm_complete_menu.js
@@ -14,6 +14,8 @@ function confirmCompleteCooking() {
     // ボタンのデータ属性からURLを取得
     const url = completeCookingButton.getAttribute('data-url');
 
+    console.log(url);
+
     // 確認ダイアログのメッセージを構築
     const confirmationMessage = "本当に" + completeCookingButton.textContent.trim() + "を調理完了してよろしいですか？";
 

--- a/app/views/completed_menus/index.html.erb
+++ b/app/views/completed_menus/index.html.erb
@@ -8,23 +8,21 @@
 
   <div class="completed-menus_list">
     <% @completed_menus.each do |item| %>
-      <% @completed_menus.each do |item| %>
-        <div class="completed-menu-item">
-          <%= link_to completed_menu_path(item, menu_id: item.menu_id, serving_size: item.menu_count, max_count: item.menu_count) do %>
-            <%= image_tag(rails_blob_path(item.menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+      <div class="completed-menu-item">
+        <%= link_to completed_menu_path(item, menu_id: item.menu_id, serving_size: item.menu_count, max_count: item.menu_count) do %>
+          <%= image_tag(rails_blob_path(item.menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
 
-            <div class="completed-menu-date">
-              <p>買出し日：<%= item.created_at.strftime('%Y/%m/%d') %></p>
-            </div>
+          <div class="completed-menu-date">
+            <p>買出し日：<%= item.created_at.strftime('%Y/%m/%d') %></p>
+          </div>
 
-            <div class="completed-menu-item-title"><%= truncate(item.menu.menu_name, length: 10, omission: '..') %></div>
+          <div class="completed-menu-item-title"><%= truncate(item.menu.menu_name, length: 10, omission: '..') %></div>
 
-            <div class="completed-menu-count">
-              <div class="menu-item-quantity"><%= item.menu_count %>人分</div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+          <div class="completed-menu-count">
+            <div class="menu-item-quantity"><%= item.menu_count %>人分</div>
+          </div>
+        <% end %>
+      </div>
     <% end %>
   </div>
 

--- a/app/views/completed_menus/show.html.erb
+++ b/app/views/completed_menus/show.html.erb
@@ -12,15 +12,15 @@
       <%= turbo_frame_tag 'ingredients_list' do %>
         <div class="show-contents-container">
           <div class="serving-adjust-button">
-            <%= button_to '◀', decrease_completed_menu_path(@menu, serving_size: @serving_size, max_count: @max_serving_size), method: :post, class: 'serving-adjust-button', data: { turbo_frame: 'ingredients_list' } %>
+            <%= button_to '◀', change_serving_size_completed_menu_path(@menu, serving_size: @serving_size, max_count: @max_serving_size, change_type: 'decrease'), method: :post, class: 'serving-adjust-button', data: { turbo_frame: 'ingredients_list' } %>
           </div>
 
           <div class="serving-size-display">
-            <p><%= @serving_size.presence || 1 %>人前</p>
+            <p><%= @serving_size %>人前</p>
           </div>
 
           <div class="serving-adjust-button">
-            <%= button_to '▶︎', increase_completed_menu_path(@menu, serving_size: @serving_size, max_count: @max_serving_size), method: :post, class: 'serving-adjust-button', data: { turbo_frame: 'ingredients_list' } %>
+            <%= button_to '▶︎', change_serving_size_completed_menu_path(@menu, serving_size: @serving_size, max_count: @max_serving_size, change_type: 'increase'), method: :post, class: 'serving-adjust-button', data: { turbo_frame: 'ingredients_list' } %>
           </div>
         </div>
 
@@ -41,7 +41,7 @@
         </div>
 
         <div class="button-container">
-          <%= button_to "#{@serving_size}人前を調理完了", "#", method: :get, class: 'complete-cooking-button', id: 'complete-cooking-button', data: { turbo: false }, "data-url": root_path %>
+          <%= button_to "#{@serving_size}人前を調理完了", "#", class: 'complete-cooking-button', id: 'complete-cooking-button', data: { turbo: false }, "data-url": mark_as_completed_menu_path(menu_id: @menu.id, serving_size: @serving_size) %>
         </div>
 
         <%= javascript_include_tag 'confirm_complete_menu' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,11 @@ Rails.application.routes.draw do
 
   resources :completed_menus do
     member do
-      post 'increase_serving', to: 'completed_menus#increase_serving', as: :increase
-      post 'decrease_serving', to: 'completed_menus#decrease_serving', as: :decrease
+      # completed_menus#showのviewで作る人数を調整する為のアクション
+      post 'change_serving_size', to: 'completed_menus#change_serving_size', as: :change_serving_size
+
+      # 作った献立を調理完了として設定するアクション
+      get 'mark_as_completed', to: 'completed_menus#mark_as_completed', as: :mark_as
     end
   end
 


### PR DESCRIPTION
目的：
調理後の処理を実装することにより、ユーザーが献立を作成し、それを完了させるまでの一連の流れを行えるようにすることが目的です。

内容：
・調理後のデータ更新機能を実装
・調理完了までの処理フローを最適化するために、献立数を調整する機能のアクションとメソッドをそれぞれ統合
・機能を実装中にコードの記述ミスがあったため合わせて修正
・「調理後のデータ更新機能を実装」の関係で、index.html.erbで完了後の献立が表示されてしまっていたため、コードを修繕

・調理完了後の画面
<img width="1427" alt="スクリーンショット 2023-12-17 16 41 15" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/3bb2679c-357c-41d9-aa9c-15fa7e19c770">
<img width="270" alt="スクリーンショット 2023-12-17 16 41 26" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/b6c3f1dc-251d-4475-a1a6-4c8e63228f18">
