### PR TITLE
CompletedMenuの更新ロジック改善＋viewの一部修正

### DIFF
--- a/app/assets/stylesheets/completed_menu/completed_menu.scss
+++ b/app/assets/stylesheets/completed_menu/completed_menu.scss
@@ -25,21 +25,9 @@
     .completed-menu-item{
       @include menu-item;
       @include hover-background(#e6e6e6);
-      height: 320px;
+      height: 300px;
       cursor: pointer;
       text-decoration: none;
-
-      .completed-menu-date {
-        font-size: 12px;
-        color: rgba(0, 0, 0, 0.6);
-        width: 100%;
-      }
-
-      .completed-menu-date p {
-        margin-top: 0px;
-        margin-bottom: 0px;
-        text-decoration: none;
-      }
 
       .rounded-image{
         @include rounded-image;

--- a/app/controllers/completed_menus_controller.rb
+++ b/app/controllers/completed_menus_controller.rb
@@ -22,14 +22,22 @@ class CompletedMenusController < ApplicationController
     begin
       ActiveRecord::Base.transaction do
 
-        # completed_menusデータを作成
         shopping_list_menus.each do |menu|
-          current_user.completed_menus.create!(
-            user_id: current_user.id,
-            menu_id: menu.menu_id,
-            menu_count: menu.menu_count,
-            is_completed: false,
-          )
+          # 既存のCompletedMenuレコードを検索する
+          # 条件は、現在のユーザー（current_user.id）が持つ、まだ完了していない（is_completed: false）特定のメニュー（menu.menu_id）
+          completed_menu = CompletedMenu.find_by(menu_id: menu.menu_id, user_id: current_user.id, is_completed: false)
+
+          if completed_menu
+            # CompletedMenuモデルに同じ献立がある場合にはmenu_countを更新するように設定
+            completed_menu.update!(menu_count: completed_menu.menu_count + menu.menu_count)
+          else
+            # CompletedMenuモデルに同じデータがない場合は、completed_menusデータを作成
+            current_user.completed_menus.create!(
+              menu_id: menu.menu_id,
+              menu_count: menu.menu_count,
+              is_completed: false,
+            )
+          end
         end
 
         # 買い物リストのデータ削除

--- a/app/views/completed_menus/index.html.erb
+++ b/app/views/completed_menus/index.html.erb
@@ -12,10 +12,6 @@
         <%= link_to completed_menu_path(item, menu_id: item.menu_id, serving_size: item.menu_count, max_count: item.menu_count) do %>
           <%= image_tag(rails_blob_path(item.menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
 
-          <div class="completed-menu-date">
-            <p>買出し日：<%= item.created_at.strftime('%Y/%m/%d') %></p>
-          </div>
-
           <div class="completed-menu-item-title"><%= truncate(item.menu.menu_name, length: 10, omission: '..') %></div>
 
           <div class="completed-menu-count">


### PR DESCRIPTION
目的：
CompletedMenuの更新処理を改善し、作れる献立の一覧表示を修正することで、重複する献立の表示を避け、一覧の見やすさを向上させることが目的です。

内容：
・CompletedMenuの更新ロジックの改善
・ビューのデザインの修正

備考：
元々は同じ種類の献立が複数配置されていましたが、既存の献立情報と同じ献立がある場合には、数量だけを更新することで同じ種類の献立が複数配置されないようになりました。

<img width="1407" alt="スクリーンショット 2023-12-17 19 46 41" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/b78e15b1-56a2-49a6-9637-b9fe511ef352">

