### PR TITLE
買い物完了時に確認ダイヤログを設定

### DIFF
--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -65,7 +65,7 @@
 
     <div class="button-container">
       <div class="shopping-complete-button">
-        <%= button_to '買い物完了', completed_menus_path, method: :post, class: 'complete-button', id: 'complete-button' %>
+        <%= button_to '買い物完了', completed_menus_path, method: :post, class: 'complete-button', id: 'complete-button', form: { data: { turbo_confirm: "買い物を完了してもよろしいですか？" }} %>
       </div>
       <%= button_to '戻る', '#', method: :get, class: 'back-button', id: 'back_button', onclick: "history.back(); return false;" %>
     </div>


### PR DESCRIPTION
目的：
買い物完了時の意図しない操作を防ぎ、ユーザー体験を向上させることが目的です。

内容：
・ユーザーが間違えて購入を確定させることを防ぐため買い物カートの「購入完了」ボタンに確認ダイヤログを追加
・確認ダイヤログには、購入確定の意思確認を明確に伝えるメッセージを表示

<img width="580" alt="スクリーンショット 2023-12-18 20 05 39" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/e86a77b9-1fd6-4846-bd60-a1c49b392800">
