### PR TITLE
Heroku用にGemfile.lockにx86_64-linuxプラットフォームを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.5.3)
     pry (0.14.2)
@@ -244,6 +246,7 @@ GEM
 PLATFORMS
   x86_64-darwin-20
   x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   action_args


### PR DESCRIPTION
目的：
Heroku上でRubyアプリケーションのデプロイを行うためです。

内容：
・Gemfile.lockにx86_64-linuxプラットフォームを追加