### PR TITLE
ログイン済みユーザーのみショッピングリスト項目が存在するかをチェックするよう修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,11 +20,7 @@ class ApplicationController < ActionController::Base
   # 現在のユーザーのカートに紐づくショッピングリストに関連するメニュー項目が存在するかをチェック
   def check_shopping_list_menu_items
     cart = current_user.cart
-    if cart && cart.shopping_list
-      @has_menu_items = cart.shopping_list.shopping_list_menus.exists?
-    else
-      @has_menu_items = false
-    end
+    @has_menu_items = cart&.shopping_list&.shopping_list_menus&.exists? || false
   end
 
   # 作れる献立がある場合にメニューバーへ「献立を選ぶ」「献立を作る」の選択肢を追加するために設定


### PR DESCRIPTION

目的：
ログイン済みユーザーに対してのみショッピングリスト関連機能を提供するという目的です。

内容：
・undefined method 'cart' for nil:NilClassエラーを解消