### PR TITLE
ログイン済みユーザーのみショッピングリスト項目が存在するかをチェックするよう再修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,8 +19,10 @@ class ApplicationController < ActionController::Base
 
   # 現在のユーザーのカートに紐づくショッピングリストに関連するメニュー項目が存在するかをチェック
   def check_shopping_list_menu_items
-    cart = current_user.cart
-    @has_menu_items = cart&.shopping_list&.shopping_list_menus&.exists? || false
+    if current_user
+      cart = current_user.cart
+      @has_menu_items = cart&.shopping_list&.shopping_list_menus&.exists? || false
+    end
   end
 
   # 作れる献立がある場合にメニューバーへ「献立を選ぶ」「献立を作る」の選択肢を追加するために設定


### PR DESCRIPTION
目的：
#111でマージした内容に誤りがあったため再度修正するためです。

内容：
・「if current_user」でログインしている場合のみ機能するように修正しました。