### PR TITLE
Herokuにdbを接続するためにデータベース設定を更新

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -79,8 +79,3 @@ test:
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #
-production:
-  <<: *default
-  database: Autonomy_app_production
-  username: Autonomy_app
-  password: <%= ENV["AUTONOMY_APP_DATABASE_PASSWORD"] %>


### PR DESCRIPTION
目的：
Herokuでのスムーズなデータベース接続を実現するため

内容：
・config/database.ymlにHerokuのDATABASE_URLを使用する設定を追加
・不要なデータベース設定の削除（個別のユーザー名やパスワードの設定）
・GemfileのPostgreSQL gem依存関係を確認