### PR TITLE
“Herokuにdbを接続するためにデータベース設定を再修正“

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -79,3 +79,6 @@ test:
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #
+production:
+  <<: *default
+  url: <%= ENV["MY_APP_DATABASE_URL"] %>


### PR DESCRIPTION
目的：
Herokuでのスムーズなデータベース接続を実現するためです。

内容：
・config/database.ymlにHerokuのDATABASE_URLを使用する設定を追加したと思っていましたが、コメントアウトが原因と思われるため、コメントアウトをとった設定をする必要があるため再修正