### PR TITLE
menuアクションの最適化により、コントローラーのコードを簡潔に整理

### DIFF
--- a/app/views/menus/edit.html.erb
+++ b/app/views/menus/edit.html.erb
@@ -13,14 +13,17 @@
 
     <div class="menu-form-input">
       <%= form_with model: @menu, url: confirm_user_menu_path(current_user), method: :post, id: "menu_form" do |f| %>
-        <%= render 'form_fields', f: f %>
-        <%= render 'image_preview', image_data_url: @image_data_url %>
         <%= f.hidden_field :menu_id, value: @menu.id %>
 
-        <% if @image_data_url.present? %>
-          <%= f.hidden_field :encoded_image, value: @encoded_image %>
-          <%= f.hidden_field :image_content_type, value: @image_content_type %>
-          <%= f.hidden_field :image_data_url, value: @image_data_url %>
+        <%= render 'form_fields', f: f %>
+
+        <% image_preview_url = params.dig(:menu, :image_data_url) || url_for(@menu.image) if @menu.image.attached? %>
+        <%= render 'image_preview', image_data_url: image_preview_url %>
+
+        <% if image_preview_url.present? %>
+          <%= f.hidden_field :encoded_image, value: params.dig(:menu, :encoded_image) || Base64.encode64(@menu.image.download) %>
+          <%= f.hidden_field :image_content_type, value: params.dig(:menu, :image_content_type) || @menu.image.content_type %>
+          <%= f.hidden_field :image_data_url, value: image_preview_url %>
         <% end %>
 
         <div class ="contents-title">
@@ -51,7 +54,7 @@
       <% end %>
 
       <div class="menu-form-back-button">
-        <%= button_to '戻る', user_menu_path(current_user, @menu), method: :get, class: 'back-button', id: 'back_button' %>
+        <%= button_to '戻る', user_menu_path(current_user, @menu), method: :get, class: 'back-button', id: 'back_button', form: { data: { turbo_confirm: "変更内容は反映されていません。よろしいでしょうか？" }} %>
       </div>
 
     </div>

--- a/app/views/menus/edit_confirm.html.erb
+++ b/app/views/menus/edit_confirm.html.erb
@@ -1,10 +1,9 @@
 <div class="confirm-container">
   <div class="confirm-form-container">
 
-    <% form_url = @menu_id ? user_menu_path(current_user, id: @menu_id) : user_menus_path(current_user) %>
-    <% form_method = @menu_id ? :patch : :post %>
+    <%= form_with model: @menu, url: user_menu_path(id: current_user.id, menu_id: @menu.id), method: :patch, local: true do |f| %>
+      <%= f.hidden_field :menu_id, value: params[:menu][:menu_id] %>
 
-    <%= form_with model: [current_user, @menu], url: form_url, method: form_method, local: true do |f| %>
       <div class="menu-confirm-container">
         <div class="menu-confirm-title">
           <h1>登録内容の最終確認</h1>
@@ -38,10 +37,14 @@
           <p>　献立画像　</p>
         </div>
         <div class ="menu-contents">
-          <% if @image_data_url.present? %>
-            <img src="<%= @image_data_url %>" width="300" height="200" alt="uploaded image preview" />
-            <%= f.hidden_field :encoded_image, value: @encoded_image %>
-            <%= f.hidden_field :image_content_type, value: @image_content_type %>
+          <% image_data_url = @image_data_url || params.dig(:menu, :image_data_url) %>
+          <% encoded_image = @encoded_image || params.dig(:menu, :encoded_image) %>
+          <% image_content_type = @image_content_type || params.dig(:menu, :image_content_type) %>
+
+          <% if image_data_url.present? %>
+            <img src="<%= image_data_url %>" width="300" height="200" alt="uploaded image preview" />
+            <%= f.hidden_field :encoded_image, value: encoded_image %>
+            <%= f.hidden_field :image_content_type, value: image_content_type %>
           <% else %>
             <p>画像なし</p>
           <% end %>
@@ -80,21 +83,24 @@
 
       <div class="button-confirm-container">
         <div class="menu-registration-button">
-          <%= f.submit @menu_id ? "更新" : "登録", name: "commit" %>
+          <%= f.submit "更新", name: "commit" %>
         </div>
       </div>
     <% end %>
 
     <div class="button-confirm-container">
       <div class="menu-edit-button">
-        <% form_edit_url = @menu_id ? edit_confirm_user_menus_path(current_user, id: @menu_id) : new_user_menu_path(current_user) %>
-        <%= form_with model: @menu, url: form_edit_url, method: :post, local: true do |f| %>
+        <%= form_with model: @menu, url: edit_confirm_user_menus_path(current_user, id: @menu.id), method: :post, local: true do |f| %>
+          <%= f.hidden_field :menu_id, value: params[:menu][:menu_id] %>
           <%= f.hidden_field :menu_name, value: @menu.menu_name %>
           <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
           <%= f.hidden_field :contents, value: @menu.contents %>
           <%= f.hidden_field :encoded_image, value: @encoded_image %>
           <%= f.hidden_field :filename, value: @menu.image.filename.to_s %>
           <%= f.hidden_field :image_content_type, value: @menu.image.content_type %>
+
+          <% image_data_url = @image_data_url || params.dig(:menu, :image_data_url) %>
+          <%= f.hidden_field :image_data_url, value: image_data_url %>
 
           <% @menu.ingredients.each_with_index do |ingredient, index| %>
             <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -14,14 +14,13 @@
     <div class="menu-form-input">
       <%= form_with model: @menu, url: confirm_user_menu_path(current_user.id), method: :post, id: "menu_form" do |f| %>
         <%= render 'form_fields', f: f %>
-        <%= render 'image_preview', image_data_url: @image_data_url %>
+        <%= render 'image_preview', image_data_url: params.dig(:menu, :image_data_url) %>
 
-        <% if @image_data_url.present? %>
-          <%= f.hidden_field :encoded_image, value: @encoded_image %>
-          <%= f.hidden_field :image_content_type, value: @image_content_type %>
-          <%= f.hidden_field :image_data_url, value: @image_data_url %>
+        <% if params.dig(:menu, :image_data_url).present? %>
+          <%= f.hidden_field :encoded_image, value: params.dig(:menu, :encoded_image) %>
+          <%= f.hidden_field :image_content_type, value: params.dig(:menu, :image_content_type) %>
+          <%= f.hidden_field :image_data_url, value: params.dig(:menu, :image_data_url) %>
         <% end %>
-
 
         <div class ="contents-title">
           <p>２.食材リスト設定</p>
@@ -51,7 +50,7 @@
       <% end %>
 
       <div class="menu-form-back-button">
-        <%= button_to '戻る', user_custom_menus_path(current_user), class: 'back-button', id: 'back_button', method: :get %>
+        <%= button_to '戻る', user_custom_menus_path(current_user), class: 'back-button', id: 'back_button', method: :get, form: { data: { turbo_confirm: "入力内容が破棄されますが、よろしいでしょうか？" }} %>
       </div>
 
     </div>

--- a/app/views/menus/new_confirm.html.erb
+++ b/app/views/menus/new_confirm.html.erb
@@ -1,0 +1,112 @@
+<div class="confirm-container">
+  <div class="confirm-form-container">
+
+    <%= form_with model: @menu, url: user_menus_path(current_user), method: :post, local: true do |f| %>
+      <div class="menu-confirm-container">
+        <div class="menu-confirm-title">
+          <h1>登録内容の最終確認</h1>
+        </div>
+
+        <div class ="contents-title">
+          <p>　献立名　</p>
+        </div>
+        <div class ="menu-contents">
+          <%= @menu.menu_name %>
+          <%= f.hidden_field :menu_name, value: @menu.menu_name %>
+        </div>
+
+        <div class ="contents-title">
+          <p>　献立内容　</p>
+        </div>
+        <div class ="menu-contents">
+          <%= @menu.menu_contents %>
+          <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
+        </div>
+
+        <div class ="contents-title">
+          <p>　作り方　</p>
+        </div>
+        <div class ="menu-contents">
+          <%= simple_format(sanitize(@menu.contents)) %>
+          <%= f.hidden_field :contents, value: @menu.contents %>
+        </div>
+
+        <div class ="contents-title">
+          <p>　献立画像　</p>
+        </div>
+        <div class ="menu-contents">
+          <% image_data_url = @image_data_url || params.dig(:menu, :image_data_url) %>
+          <% encoded_image = @encoded_image || params.dig(:menu, :encoded_image) %>
+          <% image_content_type = @image_content_type || params.dig(:menu, :image_content_type) %>
+
+          <% if image_data_url.present? %>
+            <img src="<%= image_data_url %>" width="300" height="200" alt="uploaded image preview" />
+            <%= f.hidden_field :encoded_image, value: encoded_image %>
+            <%= f.hidden_field :image_content_type, value: image_content_type %>
+          <% else %>
+            <p>画像なし</p>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="ingredient-confirm-container">
+        <div class ="contents-title">
+          <p>　食材リスト　</p>
+        </div>
+
+        <div class="ingredients-list">
+          <% if @aggregated_ingredients.present? %>
+            <% @aggregated_ingredients.each do |aggregated_ingredient| %>
+              <div class="ingredient-item">
+                <p class="material-name"><%= aggregated_ingredient.material.material_name %></p>
+                <div class="quantity-unit">
+                  <p class="quantity"><%= display_quantity(aggregated_ingredient.quantity) %></p>
+                  <p class="unit"><%= aggregated_ingredient.unit.unit_name %></p>
+                </div>
+              </div>
+            <% end %>
+          <% else %>
+            <p class="no-ingredients">食材はありません</p>
+          <% end %>
+
+          <% @menu.ingredients.each_with_index do |ingredient, index| %>
+            <%= f.hidden_field "ingredients[#{index}][material_name]", value: ingredient.material_name %>
+            <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
+            <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
+            <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
+          <% end %>
+        </div>
+      </div>
+
+
+      <div class="button-confirm-container">
+        <div class="menu-registration-button">
+          <%= f.submit "登録", name: "commit" %>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="button-confirm-container">
+      <div class="menu-edit-button">
+        <%= form_with model: @menu, url: new_user_menu_path(current_user), method: :post, local: true do |f| %>
+          <%= f.hidden_field :menu_name, value: @menu.menu_name %>
+          <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
+          <%= f.hidden_field :contents, value: @menu.contents %>
+          <%= f.hidden_field :encoded_image, value: @encoded_image %>
+          <%= f.hidden_field :filename, value: @menu.image.filename.to_s %>
+          <%= f.hidden_field :image_content_type, value: @menu.image.content_type %>
+          <%= f.hidden_field :image_data_url, value: @image_data_url %>
+
+          <% @menu.ingredients.each_with_index do |ingredient, index| %>
+            <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>
+            <%= f.hidden_field "ingredients_attributes[#{index}][material_id]", value: ingredient.material.id %>
+            <%= f.hidden_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity %>
+            <%= f.hidden_field "ingredients_attributes[#{index}][unit_id]", value: ingredient.unit.id %>
+          <% end %>
+
+          <%= f.submit "編集", class: "edit-button" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
目的：
メニュー関連の処理をビューに集約し、より効率的なコード構造を実現することが目的です。

内容：
・不要なコントローラー処理をビューに移行
・menu モデルのアクションを簡潔化
・コードの可読性向上とメンテナンス性の改善

備考：
従来のコントローラーで行われていた「postリクエストのデータをインスタンス変数に格納する処理」と「不必要なデータ加工」を削減し、受け取るデータの管理をビュー側で行うように改善しました。