### PR TITLE
確認画面の編集フォームフィールドをパーシャル化して整理

### DIFF
--- a/app/assets/stylesheets/menu/_menu_edit_confirmation_fields.scss
+++ b/app/assets/stylesheets/menu/_menu_edit_confirmation_fields.scss
@@ -1,0 +1,5 @@
+@import 'shared/menuForm';
+
+.menu-confirm-container{
+  @include flex-center-column;
+}

--- a/app/assets/stylesheets/menu/_review_edit_menu_fields.scss
+++ b/app/assets/stylesheets/menu/_review_edit_menu_fields.scss
@@ -1,0 +1,9 @@
+@import 'shared/menuForm';
+@import 'shared/styles';
+
+.edit-button{
+  @include default-button-style;
+  background-color: rgb(0, 0, 0);
+  color: rgb(255, 255, 255);
+  @include hover-background;
+}

--- a/app/assets/stylesheets/menu/menu_confirm.scss
+++ b/app/assets/stylesheets/menu/menu_confirm.scss
@@ -14,9 +14,6 @@
     .contents-title{
       @include contents-title;
     }
-    .menu-confirm-container{
-      @include flex-center-column;
-    }
 
     .ingredient-confirm-container{
       @include flex-center-column;
@@ -89,13 +86,6 @@
         background-color: #1E9AF4;
         color: white;
         @include hover-background(#aae6ff);
-      }
-
-      .edit-button{
-        @include default-button-style;
-        background-color: rgb(0, 0, 0);
-        color: rgb(255, 255, 255);
-        @include hover-background;
       }
     }
   }

--- a/app/views/menus/_menu_confirm_details.html.erb
+++ b/app/views/menus/_menu_confirm_details.html.erb
@@ -1,0 +1,81 @@
+<div class="menu-confirm-container">
+  <div class="menu-confirm-title">
+    <h1>登録内容の最終確認</h1>
+  </div>
+
+  <div class ="contents-title">
+    <p>　献立名　</p>
+  </div>
+  <div class ="menu-contents">
+    <%= menu.menu_name %>
+    <%= f.hidden_field :menu_name, value: menu.menu_name %>
+  </div>
+
+  <div class ="contents-title">
+    <p>　献立内容　</p>
+  </div>
+  <div class ="menu-contents">
+    <%= menu.menu_contents %>
+    <%= f.hidden_field :menu_contents, value: menu.menu_contents %>
+  </div>
+
+  <div class ="contents-title">
+    <p>　作り方　</p>
+  </div>
+  <div class ="menu-contents">
+    <%= simple_format(sanitize(menu.contents)) %>
+    <%= f.hidden_field :contents, value: menu.contents %>
+  </div>
+
+  <div class ="contents-title">
+    <p>　献立画像　</p>
+  </div>
+  <div class ="menu-contents">
+    <% image_data_url = image_data_url || params.dig(:menu, :image_data_url) %>
+    <% encoded_image = encoded_image || params.dig(:menu, :encoded_image) %>
+    <% image_content_type = image_content_type || params.dig(:menu, :image_content_type) %>
+
+    <% if image_data_url.present? %>
+      <img src="<%= image_data_url %>" width="300" height="200" alt="uploaded image preview" />
+      <%= f.hidden_field :encoded_image, value: encoded_image %>
+      <%= f.hidden_field :image_content_type, value: image_content_type %>
+    <% else %>
+      <p>画像なし</p>
+    <% end %>
+  </div>
+</div>
+
+<div class="ingredient-confirm-container">
+  <div class ="contents-title">
+    <p>　食材リスト　</p>
+  </div>
+
+  <div class="ingredients-list">
+    <% if aggregated_ingredients.present? %>
+      <% aggregated_ingredients.each do |aggregated_ingredient| %>
+        <div class="ingredient-item">
+          <p class="material-name"><%= aggregated_ingredient.material.material_name %></p>
+          <div class="quantity-unit">
+            <p class="quantity"><%= display_quantity(aggregated_ingredient.quantity) %></p>
+            <p class="unit"><%= aggregated_ingredient.unit.unit_name %></p>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <p class="no-ingredients">食材はありません</p>
+    <% end %>
+
+    <% menu.ingredients.each_with_index do |ingredient, index| %>
+      <%= f.hidden_field "ingredients[#{index}][material_name]", value: ingredient.material_name %>
+      <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
+      <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
+      <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
+    <% end %>
+  </div>
+</div>
+
+<div class="button-confirm-container">
+  <div class="menu-registration-button">
+    <%= f.submit button_text, name: "commit" %>
+  </div>
+</div>

--- a/app/views/menus/_review_edit_menu_fields.html.erb
+++ b/app/views/menus/_review_edit_menu_fields.html.erb
@@ -1,0 +1,16 @@
+<%= f.hidden_field :menu_name, value: menu.menu_name %>
+<%= f.hidden_field :menu_contents, value: menu.menu_contents %>
+<%= f.hidden_field :contents, value: menu.contents %>
+<%= f.hidden_field :encoded_image, value: encoded_image %>
+<%= f.hidden_field :filename, value: menu.image.filename.to_s %>
+<%= f.hidden_field :image_content_type, value: menu.image.content_type %>
+<%= f.hidden_field :image_data_url, value: image_data_url %>
+
+<% menu.ingredients.each_with_index do |ingredient, index| %>
+  <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>
+  <%= f.hidden_field "ingredients_attributes[#{index}][material_id]", value: ingredient.material.id %>
+  <%= f.hidden_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity %>
+  <%= f.hidden_field "ingredients_attributes[#{index}][unit_id]", value: ingredient.unit.id %>
+<% end %>
+
+<%= f.submit "編集", class: "edit-button" %>

--- a/app/views/menus/edit_confirm.html.erb
+++ b/app/views/menus/edit_confirm.html.erb
@@ -3,113 +3,15 @@
 
     <%= form_with model: @menu, url: user_menu_path(id: current_user.id, menu_id: @menu.id), method: :patch, local: true do |f| %>
       <%= f.hidden_field :menu_id, value: params[:menu][:menu_id] %>
-
-      <div class="menu-confirm-container">
-        <div class="menu-confirm-title">
-          <h1>登録内容の最終確認</h1>
-        </div>
-
-        <div class ="contents-title">
-          <p>　献立名　</p>
-        </div>
-        <div class ="menu-contents">
-          <%= @menu.menu_name %>
-          <%= f.hidden_field :menu_name, value: @menu.menu_name %>
-        </div>
-
-        <div class ="contents-title">
-          <p>　献立内容　</p>
-        </div>
-        <div class ="menu-contents">
-          <%= @menu.menu_contents %>
-          <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
-        </div>
-
-        <div class ="contents-title">
-          <p>　作り方　</p>
-        </div>
-        <div class ="menu-contents">
-          <%= simple_format(sanitize(@menu.contents)) %>
-          <%= f.hidden_field :contents, value: @menu.contents %>
-        </div>
-
-        <div class ="contents-title">
-          <p>　献立画像　</p>
-        </div>
-        <div class ="menu-contents">
-          <% image_data_url = @image_data_url || params.dig(:menu, :image_data_url) %>
-          <% encoded_image = @encoded_image || params.dig(:menu, :encoded_image) %>
-          <% image_content_type = @image_content_type || params.dig(:menu, :image_content_type) %>
-
-          <% if image_data_url.present? %>
-            <img src="<%= image_data_url %>" width="300" height="200" alt="uploaded image preview" />
-            <%= f.hidden_field :encoded_image, value: encoded_image %>
-            <%= f.hidden_field :image_content_type, value: image_content_type %>
-          <% else %>
-            <p>画像なし</p>
-          <% end %>
-        </div>
-      </div>
-
-      <div class="ingredient-confirm-container">
-        <div class ="contents-title">
-          <p>　食材リスト　</p>
-        </div>
-
-        <div class="ingredients-list">
-          <% if @aggregated_ingredients.present? %>
-            <% @aggregated_ingredients.each do |aggregated_ingredient| %>
-              <div class="ingredient-item">
-                <p class="material-name"><%= aggregated_ingredient.material.material_name %></p>
-                <div class="quantity-unit">
-                  <p class="quantity"><%= display_quantity(aggregated_ingredient.quantity) %></p>
-                  <p class="unit"><%= aggregated_ingredient.unit.unit_name %></p>
-                </div>
-              </div>
-            <% end %>
-          <% else %>
-            <p class="no-ingredients">食材はありません</p>
-          <% end %>
-
-          <% @menu.ingredients.each_with_index do |ingredient, index| %>
-            <%= f.hidden_field "ingredients[#{index}][material_name]", value: ingredient.material_name %>
-            <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
-            <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
-            <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
-          <% end %>
-        </div>
-      </div>
-
-
-      <div class="button-confirm-container">
-        <div class="menu-registration-button">
-          <%= f.submit "更新", name: "commit" %>
-        </div>
-      </div>
+      <%= render 'menu_confirm_details', f: f, menu: @menu, image_data_url: @image_data_url, encoded_image: @encoded_image,
+      image_content_type: @image_content_type, aggregated_ingredients: @aggregated_ingredients, button_text: "更新" %>
     <% end %>
 
     <div class="button-confirm-container">
       <div class="menu-edit-button">
         <%= form_with model: @menu, url: edit_confirm_user_menus_path(current_user, id: @menu.id), method: :post, local: true do |f| %>
           <%= f.hidden_field :menu_id, value: params[:menu][:menu_id] %>
-          <%= f.hidden_field :menu_name, value: @menu.menu_name %>
-          <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
-          <%= f.hidden_field :contents, value: @menu.contents %>
-          <%= f.hidden_field :encoded_image, value: @encoded_image %>
-          <%= f.hidden_field :filename, value: @menu.image.filename.to_s %>
-          <%= f.hidden_field :image_content_type, value: @menu.image.content_type %>
-
-          <% image_data_url = @image_data_url || params.dig(:menu, :image_data_url) %>
-          <%= f.hidden_field :image_data_url, value: image_data_url %>
-
-          <% @menu.ingredients.each_with_index do |ingredient, index| %>
-            <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>
-            <%= f.hidden_field "ingredients_attributes[#{index}][material_id]", value: ingredient.material.id %>
-            <%= f.hidden_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity %>
-            <%= f.hidden_field "ingredients_attributes[#{index}][unit_id]", value: ingredient.unit.id %>
-          <% end %>
-
-          <%= f.submit "編集", class: "edit-button" %>
+          <%= render 'review_edit_menu_fields', f: f, menu: @menu, encoded_image: @encoded_image, image_data_url: @image_data_url %>
         <% end %>
       </div>
     </div>

--- a/app/views/menus/new_confirm.html.erb
+++ b/app/views/menus/new_confirm.html.erb
@@ -2,109 +2,15 @@
   <div class="confirm-form-container">
 
     <%= form_with model: @menu, url: user_menus_path(current_user), method: :post, local: true do |f| %>
-      <div class="menu-confirm-container">
-        <div class="menu-confirm-title">
-          <h1>登録内容の最終確認</h1>
-        </div>
-
-        <div class ="contents-title">
-          <p>　献立名　</p>
-        </div>
-        <div class ="menu-contents">
-          <%= @menu.menu_name %>
-          <%= f.hidden_field :menu_name, value: @menu.menu_name %>
-        </div>
-
-        <div class ="contents-title">
-          <p>　献立内容　</p>
-        </div>
-        <div class ="menu-contents">
-          <%= @menu.menu_contents %>
-          <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
-        </div>
-
-        <div class ="contents-title">
-          <p>　作り方　</p>
-        </div>
-        <div class ="menu-contents">
-          <%= simple_format(sanitize(@menu.contents)) %>
-          <%= f.hidden_field :contents, value: @menu.contents %>
-        </div>
-
-        <div class ="contents-title">
-          <p>　献立画像　</p>
-        </div>
-        <div class ="menu-contents">
-          <% image_data_url = @image_data_url || params.dig(:menu, :image_data_url) %>
-          <% encoded_image = @encoded_image || params.dig(:menu, :encoded_image) %>
-          <% image_content_type = @image_content_type || params.dig(:menu, :image_content_type) %>
-
-          <% if image_data_url.present? %>
-            <img src="<%= image_data_url %>" width="300" height="200" alt="uploaded image preview" />
-            <%= f.hidden_field :encoded_image, value: encoded_image %>
-            <%= f.hidden_field :image_content_type, value: image_content_type %>
-          <% else %>
-            <p>画像なし</p>
-          <% end %>
-        </div>
-      </div>
-
-      <div class="ingredient-confirm-container">
-        <div class ="contents-title">
-          <p>　食材リスト　</p>
-        </div>
-
-        <div class="ingredients-list">
-          <% if @aggregated_ingredients.present? %>
-            <% @aggregated_ingredients.each do |aggregated_ingredient| %>
-              <div class="ingredient-item">
-                <p class="material-name"><%= aggregated_ingredient.material.material_name %></p>
-                <div class="quantity-unit">
-                  <p class="quantity"><%= display_quantity(aggregated_ingredient.quantity) %></p>
-                  <p class="unit"><%= aggregated_ingredient.unit.unit_name %></p>
-                </div>
-              </div>
-            <% end %>
-          <% else %>
-            <p class="no-ingredients">食材はありません</p>
-          <% end %>
-
-          <% @menu.ingredients.each_with_index do |ingredient, index| %>
-            <%= f.hidden_field "ingredients[#{index}][material_name]", value: ingredient.material_name %>
-            <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
-            <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
-            <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
-          <% end %>
-        </div>
-      </div>
-
-
-      <div class="button-confirm-container">
-        <div class="menu-registration-button">
-          <%= f.submit "登録", name: "commit" %>
-        </div>
-      </div>
+      <%= render 'menu_confirm_details', f: f, menu: @menu, image_data_url: @image_data_url, encoded_image: @encoded_image,
+      image_content_type: @image_content_type, aggregated_ingredients: @aggregated_ingredients, button_text: "登録" %>
     <% end %>
+
 
     <div class="button-confirm-container">
       <div class="menu-edit-button">
         <%= form_with model: @menu, url: new_user_menu_path(current_user), method: :post, local: true do |f| %>
-          <%= f.hidden_field :menu_name, value: @menu.menu_name %>
-          <%= f.hidden_field :menu_contents, value: @menu.menu_contents %>
-          <%= f.hidden_field :contents, value: @menu.contents %>
-          <%= f.hidden_field :encoded_image, value: @encoded_image %>
-          <%= f.hidden_field :filename, value: @menu.image.filename.to_s %>
-          <%= f.hidden_field :image_content_type, value: @menu.image.content_type %>
-          <%= f.hidden_field :image_data_url, value: @image_data_url %>
-
-          <% @menu.ingredients.each_with_index do |ingredient, index| %>
-            <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>
-            <%= f.hidden_field "ingredients_attributes[#{index}][material_id]", value: ingredient.material.id %>
-            <%= f.hidden_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity %>
-            <%= f.hidden_field "ingredients_attributes[#{index}][unit_id]", value: ingredient.unit.id %>
-          <% end %>
-
-          <%= f.submit "編集", class: "edit-button" %>
+          <%= render 'review_edit_menu_fields', f: f, menu: @menu, encoded_image: @encoded_image, image_data_url: @image_data_url %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
目的：
コードの再利用性とメンテナンスの効率化を目指します。

内容：
・メニュー確認用の編集フィールドをパーシャルに分離
・共通スタイルをSCSSファイルに定義
・ビューファイルからのパーシャル呼び出しをするよう更新

・編集時の確認画面
<img width="990" alt="スクリーンショット 2023-12-25 16 31 23" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/054d3146-6d97-43e4-9d24-1d9a4bc26cbf">
<img width="963" alt="スクリーンショット 2023-12-25 16 31 35" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/8060ac65-bd1b-4df3-8a1e-c93c8a124da9">

・新規登録時の確認画面
<img width="979" alt="スクリーンショット 2023-12-25 16 33 08" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/ea7e5eef-1cca-46da-8066-d5ff3a7ae74d">
<img width="964" alt="スクリーンショット 2023-12-25 16 33 21" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/936eb196-232f-4730-8334-1d89b474497d">