### PR TITLE
Herokuデプロイ用にGCS認証情報を環境変数に設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :google
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -32,3 +32,9 @@ local:
 #   service: Mirror
 #   primary: local
 #   mirrors: [ amazon, google, microsoft ]
+
+google:
+  service: GCS
+  project: "poised-resource-404808"
+  credentials: <%= ENV["GOOGLE_CLOUD_KEYFILE_JSON"] %>
+  bucket: "autonomy-dev-storage"


### PR DESCRIPTION
目的：
デプロイ毎に画像データが破棄されないようにすることが目的です。

内容：
・Herokuの環境変数にGoogle Cloud Storageの認証情報を設定
・Active Storageの設定をGoogle Cloud Storageに対応させるための更新
・本番環境用のstorage.ymlにGCS設定を追加
・production.rbにActive StorageのサービスをGCSに指定