### PR TITLE
献立登録・更新画面の食材表示をユーザー入力通りに変更、quantityバリデーション修正

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -61,9 +61,6 @@ class MenusController < ApplicationController
       create_ingredient_instances(@menu, filtered_ingredients)
     end
 
-    # 重複した献立を基準の単位に変換し、合算する
-    @aggregated_ingredients = aggregate_ingredients(@menu.ingredients)
-
     # 画像が新規アップロードされた場合、uploaded_fileを作成
     if params[:menu][:image].present?
       uploaded_file = params[:menu][:image]

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -6,11 +6,14 @@ class Ingredient < ApplicationRecord
 
   validates :material_name, presence: true
   validates :material_id, presence: true, length: { maximum: 15 }
-  validates :quantity, presence: true, length: { maximum: 4 }, unless: :skip_quantity_validation?
+
+# 'quantity'は10桁まで許容。小数点含むためと、合算時の桁数考慮のため
+  validates :quantity, presence: true, length: { maximum: 10 }, unless: :skip_quantity_validation?
   validates :unit_id, presence: true
 
   private
 
+  # 特定の条件下で'quantity'バリデーションをスキップ
   def skip_quantity_validation?
     settings = YAML.load_file(Rails.root.join('config', 'settings.yml'))
     unit_id == settings.dig('ingredient', 'no_quantity_unit_id')

--- a/app/views/menus/_menu_confirm_details.html.erb
+++ b/app/views/menus/_menu_confirm_details.html.erb
@@ -51,13 +51,13 @@
   </div>
 
   <div class="ingredients-list">
-    <% if aggregated_ingredients.present? %>
-      <% aggregated_ingredients.each do |aggregated_ingredient| %>
+    <% if ingredients.present? %>
+      <% ingredients.each do |ingredient| %>
         <div class="ingredient-item">
-          <p class="material-name"><%= aggregated_ingredient.material.material_name %></p>
+          <p class="material-name"><%= ingredient.material.material_name %></p>
           <div class="quantity-unit">
-            <p class="quantity"><%= display_quantity(aggregated_ingredient.quantity) %></p>
-            <p class="unit"><%= aggregated_ingredient.unit.unit_name %></p>
+            <p class="quantity"><%= display_quantity(ingredient.quantity) %></p>
+            <p class="unit"><%= ingredient.unit.unit_name %></p>
           </div>
         </div>
       <% end %>

--- a/app/views/menus/edit_confirm.html.erb
+++ b/app/views/menus/edit_confirm.html.erb
@@ -4,7 +4,7 @@
     <%= form_with model: @menu, url: user_menu_path(id: current_user.id, menu_id: @menu.id), method: :patch, local: true do |f| %>
       <%= f.hidden_field :menu_id, value: params[:menu][:menu_id] %>
       <%= render 'menu_confirm_details', f: f, menu: @menu, image_data_url: @image_data_url, encoded_image: @encoded_image,
-      image_content_type: @image_content_type, aggregated_ingredients: @aggregated_ingredients, button_text: "更新" %>
+      image_content_type: @image_content_type, ingredients: @menu.ingredients, button_text: "更新" %>
     <% end %>
 
     <div class="button-confirm-container">

--- a/app/views/menus/new_confirm.html.erb
+++ b/app/views/menus/new_confirm.html.erb
@@ -3,7 +3,7 @@
 
     <%= form_with model: @menu, url: user_menus_path(current_user), method: :post, local: true do |f| %>
       <%= render 'menu_confirm_details', f: f, menu: @menu, image_data_url: @image_data_url, encoded_image: @encoded_image,
-      image_content_type: @image_content_type, aggregated_ingredients: @aggregated_ingredients, button_text: "登録" %>
+      image_content_type: @image_content_type, ingredients: @menu.ingredients, button_text: "登録" %>
     <% end %>
 
 


### PR DESCRIPTION
目的：
ユーザーが献立登録時の食材を明確に確認できるようにし、データ登録処理での不具合を修正することが目的です。

内容：
・献立登録・更新時の食材表示を、ユーザーが入力した内容に基づく表示に変更
・食材の量を表す「quantity」フィールドのバリデーションを10桁まで許容するよう修正（小数点を含む数値と合算時の桁数を考慮する必要があるため）

備考：
・更新画面
<img width="953" alt="スクリーンショット 2023-12-27 14 55 08" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/d84a552d-1106-4a85-9f4b-24e18c35741a">
<img width="948" alt="スクリーンショット 2023-12-27 14 55 15" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/0fd7f8f7-0d4c-4679-85e1-a01b3393fc40">

・新規登録
<img width="968" alt="スクリーンショット 2023-12-27 15 17 35" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/f145769b-429a-4470-90b0-b5e8c8d8e66f">
<img width="947" alt="スクリーンショット 2023-12-27 15 17 45" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/ca2b0182-5234-4c3b-bd14-e7ff3988d4e9">
