### PR TITLE
スマホ対応の献立選択用「選択」「詳細」ボタンを追加

### DIFF
--- a/app/assets/stylesheets/menu/_menu_list.scss
+++ b/app/assets/stylesheets/menu/_menu_list.scss
@@ -1,0 +1,71 @@
+.select_menus_list{
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  padding-top: 50px;
+  gap: 10px;
+  align-items: stretch;
+  justify-content: center;
+
+  .menu-item {
+    width: 250px;
+    height: 270px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: #f8f8f8;
+    border: 1px solid #ddd;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border-radius: 20px;
+    margin-right: 10px;
+    margin-bottom: 10px;
+
+    .button-group {
+      display: flex;
+      justify-content: center;
+      gap: 10px;
+      margin-top: 10px;
+
+      .select-button,
+      .details-button {
+        padding: 10px 20px;
+        border-radius: 5px;
+        cursor: pointer;
+        text-transform: uppercase;
+        font-weight: bold;
+        border: none;
+
+        &:hover {
+          opacity: 0.5;
+        }
+      }
+
+      .select-button {
+        background-color: #3e3e3e;
+        color: white;
+        border: 2px solid #3e3e3e;
+      }
+
+      .details-button {
+        background-color: white;
+        color: #000000;
+        border: 2px solid #000000;
+      }
+    }
+  }
+
+  .menu-item-link, .menu-item-link:visited, .menu-item-link:hover, .menu-item-link:active {
+    text-decoration: none;
+  }
+
+  .menu-item-title {
+    margin-top: 10px;
+    color: black;
+    text-decoration: none;
+  }
+
+  .rounded-image {
+    border-radius: 20px;
+  }
+}

--- a/app/assets/stylesheets/menu/menu_list.scss
+++ b/app/assets/stylesheets/menu/menu_list.scss
@@ -44,52 +44,6 @@
       }
     }
 
-    .original_menus_list,
-    .sample-menus-list{
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-around;
-      padding-top: 50px;
-      gap: 10px;
-      align-items: stretch;
-      justify-content: center;
-
-      .menu-item {
-        width: 250px;
-        height: 250px;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        background-color: #f8f8f8;
-        border: 1px solid #ddd;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        border-radius: 8px;
-        border-radius: 20px;
-        margin-right: 10px;
-        margin-bottom: 10px;
-        cursor: pointer;
-
-        &:hover {
-          background-color: #e6e6e6;
-        }
-      }
-
-      .menu-item-link, .menu-item-link:visited, .menu-item-link:hover, .menu-item-link:active {
-        text-decoration: none;
-      }
-
-      .menu-item-title {
-        margin-top: 10px;
-        color: black;
-        text-decoration: none;
-      }
-
-      .rounded-image {
-        border-radius: 20px;
-      }
-    }
-
     .pagination-container {
       margin-top: 30px;
     }

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -59,7 +59,7 @@ class CartItemsController < ApplicationController
   # およびCartItemモデルからの総アイテム数を計算します。
   def total_items_count(cart)
     # ユーザーに関連するCompletedMenuモデルのアイテム数を計算
-    completed_menus_count = CompletedMenu.where(user_id: current_user.id).count
+    completed_menus_count = CompletedMenu.where(user_id: current_user.id, is_completed: false).count
 
     # ユーザーのカートに関連するShoppingListMenuモデルのアイテム数を計算
     shopping_list_menus_count = ShoppingListMenu.where(shopping_list_id: cart.shopping_list&.id).count

--- a/app/views/menus/_menu_list.html.erb
+++ b/app/views/menus/_menu_list.html.erb
@@ -1,0 +1,12 @@
+<div class="select_menus_list">
+  <% menu_list.each do |menu| %>
+    <div class="menu-item">
+      <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 150])), class: "rounded-image") %>
+      <div class="menu-item-title"><%= truncate(menu.menu_name, length: 10, omission: '..') %></div>
+      <div class="button-group">
+        <%= button_to '選択', cart_items_path(menu_id: menu.id, serving_size: serving_size), method: :post, class: 'select-button', data: { turbo: false } %>
+        <%= button_to '詳細', user_menu_path(current_user, menu), class: 'details-button', method: :get, data: { turbo: false } %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/menus/custom_menus.html.erb
+++ b/app/views/menus/custom_menus.html.erb
@@ -7,16 +7,7 @@
     <%= button_to "オリジナル献立作成", new_user_menu_path(current_user.id), class: "original-menu-button", method: :get %>
 
     <%= turbo_frame_tag 'original_menus_frame' do %>
-      <div class="original_menus_list">
-        <% @original_menus.each do |menu| %>
-          <%= link_to user_menu_path(current_user, menu), class: "menu-item-link", data: { turbo: false } do %>
-            <div class="menu-item">
-              <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
-              <div class="menu-item-title"><%= truncate(menu.menu_name, length: 10, omission: '..') %></div>
-            </div>
-          <% end %>
-        <% end %>
-      </div>
+      <%= render 'menu_list', menu_list: @original_menus, serving_size: @settings.dig('limits', 'min_serving_size') %>
 
       <%= render 'shared/pagination', total_menus_count: @total_menus_count, items_per_page: @settings.dig('pagination', 'items_per_page'),
       first_page: @settings.dig('pagination', 'first_page'), pagination_path: ->(page) { user_custom_menus_path(page: page) } %>

--- a/app/views/menus/sample_menus.html.erb
+++ b/app/views/menus/sample_menus.html.erb
@@ -6,16 +6,7 @@
   <div class="menus_list">
     <% if @default_menus.any? %>
       <%= turbo_frame_tag 'default_menus_frame' do %>
-        <div class="sample-menus-list">
-          <% @default_menus.each do |menu| %>
-            <%= link_to user_menu_path(current_user, menu), class: "menu-item-link", data: { turbo: false } do %>
-              <div class="menu-item">
-                <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
-                <div class="menu-item-title"><%= truncate(menu.menu_name, length: 10, omission: '..') %></div>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
+        <%= render 'menu_list', menu_list: @default_menus, serving_size: @settings.dig('limits', 'min_serving_size') %>
 
         <%= render 'shared/pagination', total_menus_count: @total_menus_count, items_per_page: @settings.dig('pagination', 'items_per_page'),
         first_page: @settings.dig('pagination', 'first_page'), pagination_path: ->(page) { sample_menus_path(page: page) } %>


### PR DESCRIPTION
目的：
スマホでの直感的な献立選択を可能にすることが目的です。

内容：
・「選択」ボタンを追加
・「詳細」ボタンを追加
・ボタン表示のスタイルをパーシャル化

<img width="1439" alt="スクリーンショット 2023-12-27 22 22 13" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/958d558b-f276-4680-92ad-acb34dd21c16">
<img width="1437" alt="スクリーンショット 2023-12-27 22 22 03" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/8c2fa29a-0030-4270-9f9b-1caef9e2c4de">
<img width="244" alt="スクリーンショット 2023-12-27 22 30 07" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/4ce3192a-20d8-48a8-b31f-b188a989a656">
