### PR TITLE
スマホ対応「作る」ボタン追加と視認性向上のスタイル調整

### DIFF
--- a/app/assets/stylesheets/completed_menu/completed_menu.scss
+++ b/app/assets/stylesheets/completed_menu/completed_menu.scss
@@ -24,10 +24,50 @@
 
     .completed-menu-item{
       @include menu-item;
-      @include hover-background(#e6e6e6);
-      height: 300px;
-      cursor: pointer;
+      height: 280px;
       text-decoration: none;
+      position: relative;
+
+      .ribbon {
+        position: absolute;
+        top: 10px;
+        left: 0;
+        padding: 0 12px;
+        height: 30px;
+        line-height: 30px;
+        font-size: 15px;
+        font-weight: bold;
+        background: #f78d54;
+        color: white;
+        text-align: center;
+        box-shadow: 0 2px 2px rgba(0, 0, 0, 0.12);
+        transform-origin: 0 0;
+        z-index: 10;
+      }
+
+      .ribbon:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: -7px;
+        border: none;
+        height: 38px;
+        width: 7px;
+        background: #f78d54;
+        border-radius: 5px 0 0 5px;
+      }
+
+      .ribbon:after {
+        content: '';
+        position: absolute;
+        bottom: -7px;
+        left: -5px;
+        border: none;
+        height: 7px;
+        width: 5px;
+        background: #c57b53;
+        border-radius: 5px 0 0 5px;
+      }
 
       .rounded-image{
         @include rounded-image;
@@ -35,7 +75,6 @@
 
       .completed-menu-item-title{
         @include menu-item-title;
-        font-size: 20px;
         text-decoration: none;
       }
 
@@ -47,7 +86,23 @@
         }
       }
 
-    }
+      .cooking-button{
+        margin-top: 25px;
+        .select-button{
+          padding: 10px 40px;
+          border-radius: 5px;
+          cursor: pointer;
+          font-weight: bold;
+          background-color: #3e3e3e;
+          color: white;
+          border: 2px solid #3e3e3e;
+          box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.2);
 
+          &:hover {
+            opacity: 0.7;
+          }
+        }
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/menu-bar.scss
+++ b/app/assets/stylesheets/menu-bar.scss
@@ -70,7 +70,7 @@
 
     // ハンバーガーメニューのボタンスタイル
     .hamburger {
-      z-index: 3;
+      z-index: 300;
       width: 40px;
       height: 32px;
       position: relative;
@@ -120,7 +120,7 @@
     padding: 8px 0px;
     border-radius: 4px;
     background-color: transparent;
-    z-index: 2;
+    z-index: 200;
   }
 }
 
@@ -147,5 +147,5 @@
   position: fixed;
   opacity: 0.8;
   cursor: pointer;
-  z-index: 1;
+  z-index: 100;
 }

--- a/app/assets/stylesheets/menu/_menu_list.scss
+++ b/app/assets/stylesheets/menu/_menu_list.scss
@@ -24,17 +24,18 @@
     .button-group {
       display: flex;
       justify-content: center;
-      gap: 10px;
+      gap: 20px;
       margin-top: 10px;
 
       .select-button,
       .details-button {
-        padding: 10px 20px;
+        padding: 10px 30px;
         border-radius: 5px;
         cursor: pointer;
         text-transform: uppercase;
         font-weight: bold;
         border: none;
+        box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.2);
 
         &:hover {
           opacity: 0.5;

--- a/app/views/completed_menus/index.html.erb
+++ b/app/views/completed_menus/index.html.erb
@@ -3,21 +3,20 @@
 <div class="completed-menu-container">
 
   <div class="completed-menu-heading">
-    <h3>作れる献立</h3>
+    <h3>今すぐ作れる献立</h3>
   </div>
 
   <div class="completed-menus_list">
     <% @completed_menus.each do |item| %>
       <div class="completed-menu-item">
-        <%= link_to completed_menu_path(item, menu_id: item.menu_id, serving_size: item.menu_count, max_count: item.menu_count) do %>
-          <%= image_tag(rails_blob_path(item.menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+        <div class="ribbon"><%= item.menu_count %>人前 準備OK</div>
+        <%= image_tag(rails_blob_path(item.menu.image.variant(resize_to_fill: [220, 150])), class: "rounded-image") %>
 
-          <div class="completed-menu-item-title"><%= truncate(item.menu.menu_name, length: 10, omission: '..') %></div>
+        <div class="completed-menu-item-title"><%= truncate(item.menu.menu_name, length: 10, omission: '..') %></div>
 
-          <div class="completed-menu-count">
-            <div class="menu-item-quantity"><%= item.menu_count %>人分</div>
-          </div>
-        <% end %>
+        <div class="cooking-button">
+          <%= link_to '作る', completed_menu_path(item, menu_id: item.menu_id, serving_size: item.menu_count, max_count: item.menu_count), class: 'select-button' %>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION

目的：
スマホユーザーが献立を簡単に選択し、調理をスムーズに開始できるようにするための改善です。

内容：
・「作れる献立」というページタイトルを「今すぐ作れる献立」に変更
・スマホ対応の「作る」ボタンを今すぐ作れる献立のページに追加
・献立リストのページのボタンスタイルを視覚的に認識しやすいように調整
・買い出しが完了して、今すぐ作れる献立数をリボンデザインで表示し、視覚的なわかりやすさを向上


<img width="1434" alt="スクリーンショット 2023-12-28 14 44 33" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/37758083-2e45-4225-92f9-f21d196735f5">
<img width="1435" alt="スクリーンショット 2023-12-28 14 44 25" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/344fca62-7acf-4dae-9820-e377b5b56dc5">
<img width="1440" alt="スクリーンショット 2023-12-28 14 54 44" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/41957a14-758b-4378-a7fd-cea3c279a606">
<img width="240" alt="スクリーンショット 2023-12-28 14 56 53" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/fc8795a3-62f6-4549-8656-9abd8d720ccf">
<img width="240" alt="スクリーンショット 2023-12-28 14 57 06" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/85ac710d-2b17-4519-91fd-a4eaca558daa">
<img width="238" alt="スクリーンショット 2023-12-28 14 57 21" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/6da24da0-6a8d-4f44-b1d4-b8ad20f68176">
