### PR TITLE
空のショッピングリスト時のリダイレクト処理を実装

### DIFF
--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -7,6 +7,11 @@ class ShoppingListsController < ApplicationController
     # ショッピングリストメニューを取得
     shopping_list_menus = shopping_list.shopping_list_menus.includes(menu: [image_attachment: :blob])
 
+    # ShoppingListMenuが空の場合はroot_pathへリダイレクト
+    if shopping_list_menus.empty?
+      redirect_to root_path and return
+    end
+
     # メニューデータとカウントを取得
     @menus = shopping_list_menus.map(&:menu)
     @menu_item_counts = shopping_list_menus.each_with_object({}) do |slm, counts|


### PR DESCRIPTION
目的：
ショッピングリストが空の際にユーザーを適切なページに誘導し、混乱を防ぐという目的です。

内容：
・ショッピングリストが空の場合にroot_pathへリダイレクトするよう修正