### PR TITLE
“献立の数量変更方法を統一

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,11 +16,11 @@
           <div class="menu-item-title"><%= truncate(cart_item.menu.menu_name, length: 10, omission: '..') %></div>
 
           <div class="menu-item-count">
-            <%= button_to '▲', cart_item_increment_path(cart_item), method: :post, data: { turbo_frame: "menu_item_quantity_#{cart_item.id}" }, class: "increment-button" %>
+            <%= button_to '◀︎', cart_item_decrement_path(cart_item), method: :post, data: { turbo_frame: "menu_item_quantity_#{cart_item.id}" }, class: "decrement-button" %>
             <%= turbo_frame_tag "menu_item_quantity_#{cart_item.id}" do %>
               <div class="menu-item-quantity"><%= cart_item.item_count %></div>
             <% end %>
-            <%= button_to '▼', cart_item_decrement_path(cart_item), method: :post, data: { turbo_frame: "menu_item_quantity_#{cart_item.id}" }, class: "decrement-button" %>
+            <%= button_to '▶︎', cart_item_increment_path(cart_item), method: :post, data: { turbo_frame: "menu_item_quantity_#{cart_item.id}" }, class: "increment-button" %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
目的：
ユーザーが献立の数量変更の方法を統一することで操作時にユーザーの混乱を防ぐことが目的です。

内容：
・献立の数量変更のインターフェースを一つの方法に統一（今回は選択した献立の数量変更の画面を修正しました。）

<img width="951" alt="スクリーンショット 2023-12-28 21 56 37" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/e241abe5-b528-4f45-844e-d2b67d1c28ce">
<img width="965" alt="スクリーンショット 2023-12-28 21 56 51" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/02db170b-9a75-4fa3-b26b-56d1526cb70a">
<img width="490" alt="スクリーンショット 2023-12-28 21 57 04" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/a94b5f9c-ef29-4f59-ab9f-102d45d7b500">
<img width="965" alt="スクリーンショット 2023-12-28 21 57 24" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/0e32ba74-7241-47dd-8c65-ee9ec69b3dc6">
<img width="964" alt="スクリーンショット 2023-12-28 21 57 31" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/a84face5-162d-4854-9e91-0e004e08b522">
