### PR TITLE
スマートフォン用の戻るボタンをhistory.back()からroot_pathへのリンクに変更

### DIFF
--- a/app/views/shared/_back_button.html.erb
+++ b/app/views/shared/_back_button.html.erb
@@ -1,1 +1,1 @@
-<%= link_to(image_tag('back-icon.png', alt: '前のページに戻る'), '#', class: 'scroll-to-top-button', onclick: 'history.back();return false;') %>
+<%= link_to(image_tag('back-icon.png', alt: 'ページのトップへ戻る'), root_path, class: 'scroll-to-top-button') %>


### PR DESCRIPTION
目的：
戻るボタンの動作による不具合を改善することが目的です。

内容：
・スマートフォン用戻るボタンの挙動をhistory.back()からroot_pathへのリンクに変更

備考：
スマホでの操作中にユーザーの位置とは異なるページのリダイレクトが行われていることが判明したため、現状はroot_pathへのリンクに修正しました。今後の画面設計の変更によっては再度修正が必要になってくると思われます。