### PR TITLE
スマホビューでの背景色不一致を修正、セッション関係は除外

### DIFF
--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -158,7 +158,11 @@
           border: 1px solid #ccc;
           background-color:#ffffff;
           pointer-events: none;
+          @media screen and (max-width: 400px) {
+            width: 200px;
+          }
         }
+
 
         a {
           text-decoration: none;

--- a/app/assets/stylesheets/shared/_menuForm.scss
+++ b/app/assets/stylesheets/shared/_menuForm.scss
@@ -17,8 +17,8 @@
     width: 100%;
     max-width: 800px;
     box-sizing: border-box;
-    margin: 20px auto 60px;
-    margin-bottom: 60px;
+    margin: 0px auto 60px;
+    margin-bottom: 0px;
   }
 }
 


### PR DESCRIPTION
目的：
ユーザーがスマートフォンでアプリケーションを使用する際に一貫性のある見た目にする目的です。

内容：
・スマートフォンビューにおける背景色の不一致を白色で統一
・セッションに関連するスタイルは変更から除外して一貫性を保持

・買い出し済み献立の詳細画面
<img width="254" alt="スクリーンショット 2023-12-28 22 11 43" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/63439284-6ca2-4bb7-838a-e0121f12c68d">
<img width="255" alt="スクリーンショット 2023-12-28 22 11 49" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/f610c6d9-d2ee-4f61-9943-c2f40e9ca2f8">

・献立選択画面（オリジナル献立）
<img width="254" alt="スクリーンショット 2023-12-28 22 12 09" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/00458fcb-0b0c-43b0-89c9-b9c5bfe8eb03">
<img width="252" alt="スクリーンショット 2023-12-28 22 12 17" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/7f2f9f68-09eb-41a7-ad99-e980894065d2">

・献立登録
<img width="253" alt="スクリーンショット 2023-12-28 22 12 28" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/dc6b7770-6bce-4d42-8fee-ab937314627c">
<img width="257" alt="スクリーンショット 2023-12-28 22 12 37" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/a77e3285-e634-4bd4-a288-ec59986252a9">

・献立選択画面（サンプル献立）
<img width="254" alt="スクリーンショット 2023-12-28 22 13 02" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/20fdf04e-95a5-4853-8fdd-119b129c78d2">
<img width="252" alt="スクリーンショット 2023-12-28 22 13 10" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/f7de7962-29fc-490d-a247-113d68e81214">

・買い物リスト
<img width="254" alt="スクリーンショット 2023-12-28 22 13 26" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/0f2e57b8-f676-4241-8d9f-4967ea5e90c3">
<img width="254" alt="スクリーンショット 2023-12-28 22 13 32" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/d87c3592-f1ee-4aca-9965-aaff977c5726">
