### PR TITLE
ユーザー情報とパスワード更新の分離及びバリデーション強化

### DIFF
--- a/app/assets/stylesheets/custom_registration.scss
+++ b/app/assets/stylesheets/custom_registration.scss
@@ -7,10 +7,6 @@
     @include form-title;
   }
 
-  .registration-instructions {
-    @include form-instructions;
-  }
-
   .registration-field input {
     @include field-form;
   }

--- a/app/assets/stylesheets/edit_custom_registration.scss
+++ b/app/assets/stylesheets/edit_custom_registration.scss
@@ -14,7 +14,10 @@
 
   .registration-input{
     width: 50%;
-    @media screen and (max-width: 400px){
+    @media screen and (max-width: 1000px){
+      width: 70%;
+    }
+    @media screen and (max-width: 900px){
       width: 90%;
     }
 
@@ -32,6 +35,11 @@
 
   .registration-field input{
     @include field-form
+  }
+
+  .registration-link {
+    text-align: center;
+    margin-bottom: 20px;
   }
 
   .registration-actions{

--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -38,38 +38,82 @@ class CustomRegistrationsController < ApplicationController
   def edit
   end
 
+  def edit_password
+  end
+
   def update
-    # パスワードがない場合
-    unless edit_user_params[:password].present? && edit_user_params[:password_confirmation].present?
-      current_user.update(user_params_without_password)
-      flash[:notice] = "ユーザー情報を更新（パスワード未更新）"
-      render :edit
+    # ユーザー情報の更新
+    if user_params.present?
+      update_user_info
       return
     end
 
-    # パスワードが一致しない場合
-    if current_user.valid_password?(edit_user_params[:current_password])
-      current_user.update(edit_user_params)
-      flash[:notice] = "ユーザー情報とパスワードを更新再度ログインをお願いします。"
-      redirect_to user_custom_session_path
-    else
-      flash[:notice] = "現在のパスワードが正しくありません。"
-      render :edit
+    # パスワード更新
+    # 未入力があるかチェック
+    if !password_params.keys.all? { |key| password_params[key].present? }
+      flash[:error] = "未入力がありました。"
+      redirect_to edit_password_user_custom_registration_path
+      return
     end
+
+    # 現在のパスワードがあっているかチェック
+    if !current_user.valid_password?(password_params[:current_password])
+      flash[:error] = "入力された「現在のパスワード」が正しくありません。"
+      redirect_to edit_password_user_custom_registration_path
+      return
+    end
+
+    # パスワードをアップデート
+    if current_user.update(password_params)
+      flash[:notice] = "パスワードを更新しました。再度ログインをお願いします。"
+      redirect_to edit_password_user_custom_registration_path
+      return
+
+    # パスワードの「形式誤り」と「新しいパスワードと再入力が一致しない」場合の処理
+    else
+      check_password_errors
+      redirect_to edit_password_user_custom_registration_path
+    end
+
   end
 
   private
 
+  def set_flash_error_messages
+    if current_user.errors.details[:name].any? { |error| error[:error] == :blank } ||
+       current_user.errors.details[:email].any? { |error| error[:error] == :blank }
+      flash[:error] = "未入力の項目がありました。"
+    else
+      flash[:error] = "ユーザー情報の更新に失敗しました。"
+    end
+  end
+
+  # ユーザー情報の更新を行うメソッド
+  def update_user_info
+    if current_user.update(user_params)
+      flash[:notice] = "ユーザー情報を更新しました。"
+      redirect_to edit_user_custom_registration_path
+    else
+      set_flash_error_messages
+      redirect_to edit_user_custom_registration_path
+    end
+  end
+
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
-  end
-
-  def edit_user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, :current_password)
-  end
-
-  def user_params_without_password
     params.require(:user).permit(:name, :email)
+  end
+
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation, :current_password)
+  end
+
+  # パスワードの「形式誤り」か「新しいパスワードと再入力が一致しない」場合にエラーメッセージを設定する
+  def check_password_errors
+    if current_user.errors.added?(:password_confirmation, "doesn't match Password")
+      flash[:error] = "新しいパスワード(確認)は新しいパスワードと一致しません。"
+    elsif current_user.errors.added?(:password, "is invalid")
+      flash[:error] = "パスワードには英字と数字を両方含む必要があります。"
+    end
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,15 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
+  validates :name, presence: true, length: { maximum: 15 }
+  validates :email, presence: true
+
+  # パスワードのバリデーション（更新時のみ）
+  validates :password, presence: true, on: :update, if: :password_changed?
+  validates :password, confirmation: true, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i }, on: :update, if: :password_changed?
+  validates :password_confirmation, presence: true, on: :update, if: :password_changed?
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   attr_accessor :current_password

--- a/app/views/custom_registrations/edit.html.erb
+++ b/app/views/custom_registrations/edit.html.erb
@@ -5,7 +5,7 @@
   </div>
 
   <div class="registration-instructions">
-    <p>※パスワードの入力は必須ではありません。</p>
+    <p>登録内容は管理者および本人以外には公開されません。</p>
   </div>
 
   <div class="registration-input">
@@ -18,16 +18,8 @@
         <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス" %>
       </div>
 
-      <div class="registration-field">
-        <%= f.password_field :current_password, autocomplete: "current_password", placeholder: "現在のパスワードを入力" %>
-      </div>
-
-      <div class="registration-field">
-        <%= f.password_field :password, autocomplete: "password", placeholder: "新しいパスワードを入力" %>
-      </div>
-
-      <div class="registration-field">
-        <%= f.password_field :password_confirmation, autocomplete: "password_confirmation", placeholder: "もう一度新しいパスワードを入力" %>
+      <div class="registration-link">
+        <%= link_to "パスワードを変更する", edit_password_user_custom_registration_path, class: "password-change-link" %>
       </div>
 
       <div class="registration-actions">

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -1,0 +1,38 @@
+<div class="edit-registration-container">
+
+  <div class="registration-title">
+    <h1>パスワード変更</h1>
+  </div>
+
+  <div class="registration-instructions">
+    <p>パスワード変更後、新しいパスワードで再ログインが必要です。</p>
+  </div>
+
+  <div class="registration-input">
+    <%= form_with model: current_user, url: update_user_custom_registration_path, local: true, method: :patch do |f| %>
+
+      <div class="registration-field">
+        <%= f.text_field :current_password, autocomplete: "current_password", placeholder: "現在のパスワードを入力" %>
+      </div>
+
+      <div class="registration-field">
+        <%= f.password_field :password, autocomplete: "password", placeholder: "新しいパスワードを入力" %>
+      </div>
+
+      <div class="registration-field">
+        <%= f.password_field :password_confirmation, autocomplete: "password_confirmation", placeholder: "もう一度新しいパスワードを入力" %>
+      </div>
+
+      <div class="registration-link">
+        <%= link_to "ユーザー情報更新画面へ戻る", edit_user_custom_registration_path, class: "user-edit-link" %>
+      </div>
+
+      <div class="registration-actions">
+        <%= f.submit "更新" %>
+      </div>
+    <% end %>
+    <div class="registration-back-button">
+      <%= button_to "戻る", root_path, class: "back-button", method: :get %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
     post 'users/session', to: 'custom_sessions#create', as: :user_custom_session
     get 'users/sessions', to: 'custom_sessions#destroy', as: :destroy_user_custom_session
     get 'registrations/edit', to: 'custom_registrations#edit', as: :edit_user_custom_registration
+    get 'registrations/edit_password', to: 'custom_registrations#edit_password', as: :edit_password_user_custom_registration
     patch 'registrations/update', to: 'custom_registrations#update', as: :update_user_custom_registration
 
     resources :users do


### PR DESCRIPTION
目的：
ユーザーの利便性向上とセキュリティ強化を目的としています。

内容：
・「ユーザー情報更新」と「パスワード更新」の画面を分離
・Userモデルにバリデーション設定
・パスワードフィールドの空チェックを実装
・指定形式に沿ったパスワード確認と一致チェックの追加
・パスワード確認フィールドの空チェックを実装
・更新時のみバリデーションが適用されるよう設定 

<img width="821" alt="スクリーンショット 2024-01-02 18 10 33" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/c8426e0d-3a96-4395-b0f9-64ace4edb6e4">
<img width="838" alt="スクリーンショット 2024-01-02 18 12 43" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/17ad1d4e-fa8d-4729-9856-2c1e314a633a">

