### PR TITLE
ユーザー情報の登録/更新時のバリデーション強化、およびログイン/新規登録時のバリデーション強化

### DIFF
--- a/app/assets/stylesheets/custom_registration.scss
+++ b/app/assets/stylesheets/custom_registration.scss
@@ -7,23 +7,38 @@
     @include form-title;
   }
 
-  .registration-field input {
-    @include field-form;
+  .registration-instructions{
+    @include form-instructions;
   }
 
-  .registration-actions {
-    @include form-submit-button;
-  }
+  .registration-input{
+    width: 40%;
+    @media screen and (max-width: 1300px) {
+      width: 65%;
+    }
+    @media screen and (max-width: 850px) {
+      width: 100%;
+    }
 
-  .registration-actions input[type="submit"] {
-    @include form-submit-button-input;
-  }
+    .registration-field input {
+      @include field-form;
+    }
 
-  .registration-link{
-    @include form-link;
-  }
+    .registration-actions {
+      @include form-submit-button;
+    }
 
-  .registration-link a {
-    text-decoration: none;
+    .registration-actions input[type="submit"] {
+      @include form-submit-button-input;
+    }
+
+    .registration-link{
+      @include form-link;
+      margin-bottom: 30px;
+    }
+
+    .registration-link a {
+      text-decoration: none;
+    }
   }
 }

--- a/app/assets/stylesheets/custom_session.scss
+++ b/app/assets/stylesheets/custom_session.scss
@@ -19,9 +19,12 @@
     }
 
     .session-input{
-      width: 33%;
-      @media screen and (max-width: 700px) {
-        width: 50%;
+      width: 50%;
+      @media screen and (max-width: 1300px) {
+        width: 65%;
+      }
+      @media screen and (max-width: 600px) {
+        width: 100%;
       }
     }
 

--- a/app/controllers/concerns/flash_and_redirect.rb
+++ b/app/controllers/concerns/flash_and_redirect.rb
@@ -1,0 +1,7 @@
+module FlashAndRedirect
+  # メッセージとリダイレクトパスを設定するメソッド
+  def set_flash_and_redirect(flash_key, message, redirect_path)
+    flash[flash_key] = message
+    redirect_to redirect_path
+  end
+end

--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -1,5 +1,5 @@
 class CustomRegistrationsController < ApplicationController
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, only: [:new, :create]
 
   def new
     @user = User.new
@@ -7,31 +7,16 @@ class CustomRegistrationsController < ApplicationController
 
   def create
     #user情報を格納する
-    user = User.new(user_params)
+    user = User.new(new_registration_params)
 
-    #入力したデータでエラーがないかチェック
-    if User.find_by(name: user.name)
-      flash[:notice] = "※そのユーザー名は既に使用されています。"
-      render 'new'
-      return
-    elsif User.find_by(email: user.email)
-      flash[:notice] = "※そのメールアドレスは既に使用されています。"
-      render 'new'
-      return
-    elsif user.password != user.password_confirmation
-      flash[:notice] = "※入力したパスワードが一致しません。"
-      render 'new'
-      return
-    end
-
-    #問題なければログインする
-    if flash[:sign_up_notice].present?
-      render 'new'
-    elsif user.save
+    if user.save
       session[:user_id] = user.id
       sign_in(user)
       flash[:notice] = "ログインしました。"
       redirect_to root_path
+    else
+      set_error_flash(user)
+      redirect_to new_user_custom_registration_path
     end
   end
 
@@ -43,77 +28,41 @@ class CustomRegistrationsController < ApplicationController
 
   def update
     # ユーザー情報の更新
-    if user_params.present?
-      update_user_info
+    if user_params.present? && current_user.update(user_params)
+      flash[:notice] = "ユーザー情報を更新しました。"
+      redirect_to edit_user_custom_registration_path
+      return
+    elsif user_params.present?
+      set_error_flash(current_user)
+      redirect_to edit_user_custom_registration_path
       return
     end
 
     # パスワード更新
-    # 未入力があるかチェック
-    if !password_params.keys.all? { |key| password_params[key].present? }
-      flash[:error] = "未入力がありました。"
-      redirect_to edit_password_user_custom_registration_path
-      return
-    end
-
-    # 現在のパスワードがあっているかチェック
-    if !current_user.valid_password?(password_params[:current_password])
-      flash[:error] = "入力された「現在のパスワード」が正しくありません。"
-      redirect_to edit_password_user_custom_registration_path
-      return
-    end
-
-    # パスワードをアップデート
     if current_user.update(password_params)
       flash[:notice] = "パスワードを更新しました。再度ログインをお願いします。"
-      redirect_to edit_password_user_custom_registration_path
-      return
-
-    # パスワードの「形式誤り」と「新しいパスワードと再入力が一致しない」場合の処理
+      redirect_to root_path
     else
-      check_password_errors
+      set_error_flash(current_user)
       redirect_to edit_password_user_custom_registration_path
     end
 
   end
 
   private
-
-  def set_flash_error_messages
-    if current_user.errors.details[:name].any? { |error| error[:error] == :blank } ||
-       current_user.errors.details[:email].any? { |error| error[:error] == :blank }
-      flash[:error] = "未入力の項目がありました。"
-    else
-      flash[:error] = "ユーザー情報の更新に失敗しました。"
-    end
-  end
-
-  # ユーザー情報の更新を行うメソッド
-  def update_user_info
-    if current_user.update(user_params)
-      flash[:notice] = "ユーザー情報を更新しました。"
-      redirect_to edit_user_custom_registration_path
-    else
-      set_flash_error_messages
-      redirect_to edit_user_custom_registration_path
-    end
-  end
-
   def user_params
     params.require(:user).permit(:name, :email)
+  end
+
+  def new_registration_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :current_password)
   end
 
   def password_params
     params.require(:user).permit(:password, :password_confirmation, :current_password)
   end
 
-  # パスワードの「形式誤り」か「新しいパスワードと再入力が一致しない」場合にエラーメッセージを設定する
-  def check_password_errors
-    if current_user.errors.added?(:password_confirmation, "doesn't match Password")
-      flash[:error] = "新しいパスワード(確認)は新しいパスワードと一致しません。"
-    elsif current_user.errors.added?(:password, "is invalid")
-      flash[:error] = "パスワードには英字と数字を両方含む必要があります。"
-    end
+  def set_error_flash(user)
+    flash[:error] = user.errors.full_messages.first.sub(/^.*\s/, '')
   end
-
 end

--- a/app/controllers/custom_sessions_controller.rb
+++ b/app/controllers/custom_sessions_controller.rb
@@ -5,8 +5,8 @@ class CustomSessionsController < ApplicationController
   end
 
   def create
-    #userのidとパスワードを格納する
-    user = User.find_by(name: params[:name])
+    #userのemailとパスワードを格納する
+    user = User.find_by(email: params[:email])
     #userとパスワードが一致するか確認
     if user && user.valid_password?(params[:password])
       #セッションIDを払い出す
@@ -18,9 +18,9 @@ class CustomSessionsController < ApplicationController
       redirect_to root_path
     else
       #ログインできませんでしたとアナウンス
-      flash[:notice] = "※入力した情報が違います。"
+      flash[:error] = "※ユーザー名もしくはパスワードが間違っています。"
       #合わない場合にはsessions#newへ戻る
-      render 'new'
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/custom_sessions_controller.rb
+++ b/app/controllers/custom_sessions_controller.rb
@@ -1,10 +1,16 @@
 class CustomSessionsController < ApplicationController
+  include FlashAndRedirect
   skip_before_action :authenticate_user!
 
   def new
   end
 
   def create
+    if params[:email].blank? || params[:password].blank?
+      set_flash_and_redirect(:error, "未入力があります。", root_path)
+      return
+    end
+
     #userのemailとパスワードを格納する
     user = User.find_by(email: params[:email])
     #userとパスワードが一致するか確認
@@ -13,14 +19,12 @@ class CustomSessionsController < ApplicationController
       session[:user_id] = user.id
       # current_userに値を設定する
       sign_in(user)
-      flash[:notice] = "ログインしました。"
       #もし一致する場合にはroot_pathへ移動
-      redirect_to root_path
+      set_flash_and_redirect(:notice, "ログインしました。", root_path)
     else
       #ログインできませんでしたとアナウンス
-      flash[:error] = "※ユーザー名もしくはパスワードが間違っています。"
       #合わない場合にはsessions#newへ戻る
-      redirect_to root_path
+      set_flash_and_redirect(:error, "※ユーザー名もしくはパスワードが間違っています。", root_path)
     end
   end
 
@@ -32,8 +36,7 @@ class CustomSessionsController < ApplicationController
     #セッションの完全な処理
     reset_session
     #sessions#newへ戻る
-    flash[:notice] = "※ログアウトしました。"
     #一時的にsigninの画面にパスを出しています。
-    redirect_to new_user_custom_session_path
+    set_flash_and_redirect(:notice, "※ログアウトしました。", new_user_custom_session_path)
   end
 end

--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -1,4 +1,7 @@
-document.getElementById('next_step_button').addEventListener('submit', function(event) {
+document.addEventListener('submit', function(event) {
+  // イベントが発生したフォーム内の 'next_step_button' を探し、ない場合には処理を行わない。
+  let nextStepButton = event.target.querySelector('#next_step_button');
+  if (!nextStepButton) return;
 
   let minForm = 0;
   let maxForm = 14;
@@ -37,6 +40,9 @@ document.getElementById('next_step_button').addEventListener('submit', function(
 
 function validateAndHighlightInput(element ,sub_errorMessage, inputElement, event) {
   let menu_main_errorMessage = document.getElementById("main-menu-error");
+  console.log("きています。");
+  console.log(element);
+  console.log(inputElement);
   if (element.value === "" ) {
     event.preventDefault();
     menu_main_errorMessage.textContent = "⚠️未入力があります。";

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,23 +2,17 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
 
-  validates :name, presence: { message: "ユーザー名は必須です" },
-    length: { maximum: 8, too_long: "ユーザー名は最大%{count}文字までです" }
-
+  validates :name, presence: { message: "ユーザー名は必須です。" },
+    length: { maximum: 8, too_long: "ユーザー名は最大%{count}文字までです。" }
   validates :email, presence: { message: "メールアドレスは必須です" },
-    uniqueness: { case_sensitive: false, message: "このメールアドレスは既に使用されています" },
-    length: { maximum: 254, too_long: "メールアドレスは最大%{count}文字までです" }
+    uniqueness: { case_sensitive: false, message: "このメールアドレスは既に使用されています。" },
+    length: { maximum: 254, too_long: "メールアドレスは最大%{count}文字までです。" }
 
   # パスワードのバリデーションを新規作成と更新の両方で適用
   # パスワードが変更された場合、または新規作成の場合に検証する
-
-  validates :password, presence: { message: "新しいパスワードは必須です" },
-    length: { minimum: 8, too_short: "パスワードは最低%{count}文字必要です" }, if: :password_present?
-
-  validates :password, confirmation: { message: "パスワードと確認用パスワードが一致しません" },
-    format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: "パスワードは英数字を含む必要があります" }, if: :password_present?
-
-  validates :password_confirmation, presence: { message: "確認用パスワードの入力は必須です" }, if: :password_present?
+  validates :password, length: { minimum: 8, too_short: "パスワードは最低%{count}文字必要です。" }, if: :password_present?
+  validates :password, confirmation: { message: "新しいパスワードと確認用パスワードが一致しません。" },
+    format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: "パスワードは英数字を含む必要があります。" }, if: :password_present?
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
@@ -32,12 +26,6 @@ class User < ApplicationRecord
   has_many :completed_menus, dependent: :destroy
 
   private
-
-  # def current_password_is_correct
-  #   if !valid_password?(current_password)
-  #     errors.add(:current_password, '現在のパスワードが正しくありません')
-  #   end
-  # end
 
   def password_present?
     password.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,17 +11,17 @@ class User < ApplicationRecord
 
   # パスワードのバリデーションを新規作成と更新の両方で適用
   # パスワードが変更された場合、または新規作成の場合に検証する
-  validates :password, presence: { message: "パスワードは必須です" },
+
+  validates :password, presence: { message: "新しいパスワードは必須です" },
     length: { minimum: 8, too_short: "パスワードは最低%{count}文字必要です" }, if: :password_present?
 
   validates :password, confirmation: { message: "パスワードと確認用パスワードが一致しません" },
     format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: "パスワードは英数字を含む必要があります" }, if: :password_present?
 
   validates :password_confirmation, presence: { message: "確認用パスワードの入力は必須です" }, if: :password_present?
-  validate :current_password_is_correct, if: :password_present?
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable
+         :recoverable, :rememberable, :validatable
   attr_accessor :current_password
 
   has_many :menu_users, dependent: :destroy
@@ -31,16 +31,15 @@ class User < ApplicationRecord
   has_many :shopping_lists, dependent: :destroy
   has_many :completed_menus, dependent: :destroy
 
-
   private
 
-  def current_password_is_correct
-    if current_password.present? && valid_password?(current_password)
-      errors.add(:current_password, '現在のパスワードが正しくありません')
-    end
-  end
+  # def current_password_is_correct
+  #   if !valid_password?(current_password)
+  #     errors.add(:current_password, '現在のパスワードが正しくありません')
+  #   end
+  # end
 
   def password_present?
-    !password.blank?
+    password.present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,16 +2,26 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
 
-  validates :name, presence: true, length: { maximum: 15 }
-  validates :email, presence: true
+  validates :name, presence: { message: "ユーザー名は必須です" },
+    length: { maximum: 8, too_long: "ユーザー名は最大%{count}文字までです" }
 
-  # パスワードのバリデーション（更新時のみ）
-  validates :password, presence: true, on: :update, if: :password_changed?
-  validates :password, confirmation: true, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i }, on: :update, if: :password_changed?
-  validates :password_confirmation, presence: true, on: :update, if: :password_changed?
+  validates :email, presence: { message: "メールアドレスは必須です" },
+    uniqueness: { case_sensitive: false, message: "このメールアドレスは既に使用されています" },
+    length: { maximum: 254, too_long: "メールアドレスは最大%{count}文字までです" }
+
+  # パスワードのバリデーションを新規作成と更新の両方で適用
+  # パスワードが変更された場合、または新規作成の場合に検証する
+  validates :password, presence: { message: "パスワードは必須です" },
+    length: { minimum: 8, too_short: "パスワードは最低%{count}文字必要です" }, if: :password_present?
+
+  validates :password, confirmation: { message: "パスワードと確認用パスワードが一致しません" },
+    format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: "パスワードは英数字を含む必要があります" }, if: :password_present?
+
+  validates :password_confirmation, presence: { message: "確認用パスワードの入力は必須です" }, if: :password_present?
+  validate :current_password_is_correct, if: :password_present?
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable
   attr_accessor :current_password
 
   has_many :menu_users, dependent: :destroy
@@ -20,4 +30,17 @@ class User < ApplicationRecord
   has_many :completed_menus, dependent: :destroy
   has_many :shopping_lists, dependent: :destroy
   has_many :completed_menus, dependent: :destroy
+
+
+  private
+
+  def current_password_is_correct
+    if current_password.present? && valid_password?(current_password)
+      errors.add(:current_password, '現在のパスワードが正しくありません')
+    end
+  end
+
+  def password_present?
+    !password.blank?
+  end
 end

--- a/app/views/custom_registrations/edit.html.erb
+++ b/app/views/custom_registrations/edit.html.erb
@@ -11,7 +11,7 @@
   <div class="registration-input">
     <%= form_with model: current_user, url: update_user_custom_registration_path, local: true, method: :patch do |f| %>
       <div class="registration-field">
-        <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "ニックネーム" %>
+        <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "ユーザー名" %>
       </div>
 
       <div class="registration-field">

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -12,15 +12,15 @@
     <%= form_with model: current_user, url: update_user_custom_registration_path, local: true, method: :patch do |f| %>
 
       <div class="registration-field">
-        <%= f.text_field :current_password, autocomplete: "current_password", placeholder: "現在のパスワードを入力" %>
+        <%= f.text_field :current_password, name: 'user[current_password]', autocomplete: "current_password", placeholder: "現在のパスワードを入力" %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password, autocomplete: "password", placeholder: "新しいパスワードを入力" %>
+        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "新しいパスワードを入力" %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password_confirmation, autocomplete: "password_confirmation", placeholder: "もう一度新しいパスワードを入力" %>
+        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "もう一度新しいパスワードを入力" %>
       </div>
 
       <div class="registration-link">

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="registration-input">
-    <%= form_with model: current_user, url: update_user_custom_registration_path, local: true, method: :patch do |f| %>
+    <%= form_with model: current_user, url: password_info_update_custom_registration_path, local: true, method: :patch do |f| %>
 
       <div class="registration-field">
         <%= f.text_field :current_password, name: 'user[current_password]', autocomplete: "current_password", placeholder: "現在のパスワードを入力" %>

--- a/app/views/custom_registrations/edit_user.html.erb
+++ b/app/views/custom_registrations/edit_user.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="registration-input">
-    <%= form_with model: current_user, url: update_user_custom_registration_path, local: true, method: :patch do |f| %>
+    <%= form_with model: current_user, url: user_info_update_custom_registration_path, local: true, method: :patch do |f| %>
       <div class="registration-field">
         <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "ユーザー名" %>
       </div>

--- a/app/views/custom_registrations/new.html.erb
+++ b/app/views/custom_registrations/new.html.erb
@@ -1,33 +1,33 @@
 <div class="new-registration-container">
 
   <div class="registration-title">
-    <h1>Sign up</h1>
+    <h1>ユーザー新規登録</h1>
   </div>
 
   <div class="registration-instructions">
-    <p>※未入力があるとSigin upができません。</p>
+    <p>※未入力があると登録ができません。</p>
   </div>
 
   <div class="registration-input">
     <%= form_with url: user_custom_registration_path, local: true do |f| %>
       <div class="registration-field">
-        <%= f.text_field :name, name: 'user[name]', autofocus: true, autocomplete: "name", placeholder: "ニックネーム" %>
+        <%= f.text_field :name, name: 'user[name]', autofocus: true, autocomplete: "name", placeholder: "ユーザー名", maxlength: 8 %>
       </div>
 
       <div class="registration-field">
-        <%= f.email_field :email, name: 'user[email]', autofocus: true, autocomplete: "email", placeholder: "メールアドレス" %>
+        <%= f.email_field :email, name: 'user[email]', autofocus: true, autocomplete: "email", placeholder: "メールアドレス", maxlength: 254 %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "パスワード" %>
+        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "パスワード（最低8桁の英数字を含む）", maxlength: 20 %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "再度パスワード入力" %>
+        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "確認用パスワード", maxlength: 20 %>
       </div>
 
       <div class="registration-actions">
-        <%= f.submit "Sigin up" %>
+        <%= f.submit "登録" %>
       </div>
 
       <div class="registration-link">

--- a/app/views/custom_sessions/new.html.erb
+++ b/app/views/custom_sessions/new.html.erb
@@ -1,23 +1,23 @@
 <div class="new-session-container">
 
   <div class="session-title">
-    <h1>Sign in</h1>
+    <h1>ログイン</h1>
   </div>
 
   <div class="session-instructions">
-    <p>※未入力があるとLog inができません。</p>
+    <p>※未入力があるとログインができません。</p>
   </div>
 
   <div class="session-input">
     <%= form_with url: user_custom_session_path, local: true, data: { turbo: false } do |f| %>
       <div class="session-field">
-        <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "ニックネーム" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", maxlength: 254 %>
       </div>
       <div class="session-field">
-        <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード" %>
+        <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード（最低8桁の英数字を含む）", maxlength: 20 %>
       </div>
       <div class="session-actions">
-        <%= f.submit "Log in" %>
+        <%= f.submit "ログイン" %>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,9 +38,14 @@ Rails.application.routes.draw do
     get 'users/session', to: 'custom_sessions#new', as: :new_user_custom_session
     post 'users/session', to: 'custom_sessions#create', as: :user_custom_session
     get 'users/sessions', to: 'custom_sessions#destroy', as: :destroy_user_custom_session
-    get 'registrations/edit', to: 'custom_registrations#edit', as: :edit_user_custom_registration
+    get 'registrations/edit_user', to: 'custom_registrations#edit_user', as: :edit_user_custom_registration
     get 'registrations/edit_password', to: 'custom_registrations#edit_password', as: :edit_password_user_custom_registration
-    patch 'registrations/update', to: 'custom_registrations#update', as: :update_user_custom_registration
+    # patch 'registrations/update', to: 'custom_registrations#update', as: :update_user_custom_registration
+
+    # ユーザー情報更新用のルーティング
+    patch 'registrations/update_user_info', to: 'custom_registrations#user_info_update', as: :user_info_update_custom_registration
+    # パスワード情報更新用のルーティング
+    patch 'registrations/update_password_info', to: 'custom_registrations#password_info_update', as: :password_info_update_custom_registration
 
     resources :users do
       resources :menus do


### PR DESCRIPTION
目的：
ユーザー情報の登録更新およびログイン機能を改善することで、システムの整合性と利用者の利便性向上をさせることが目的です。

内容：
・Userモデルのバリデーションを強化し、データの正確性を確保
・CustomRegistrationsController内の不要なバリデーション処理を削除
・ビューの日本語表記への変更、フォームのサイズ調整、文字数制限の追加で表示を改善
・ログイン時の認証情報を「ユーザー名」と「パスワード」から「メールアドレス」と「パスワード」へ変更
・CustomSessionsControllerのセッション管理ロジックを修正し、ログイン処理の改善

備考：
今回の改善により、コントローラーでのバリデーション設定を削減できたため、コントローラーの処理を圧迫を軽減させることができました。

また他のサービスではログインするときに「ユーザー名」と「パスワード」ではなく、「メールアドレス」と「パスワード」の組み合わせの例が多かった点、ユニークな識別子である点、ユーザー名が公開情報であることが多いのに対し、メールアドレスはより個人的で保護された情報である点からしても「メールアドレス」と「パスワード」の組み合わせが適切と判断しました。

バリデーションでは全てのエラーが表示されるかテストを行い、エラーが全て出たことを確認しています。
今後はjsにて動的バリデーションを実装する予定です。

ログイン画面：
・ログイン画面のビュー
<img width="1435" alt="スクリーンショット 2024-01-08 13 19 12" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/30db73a2-51ea-41dc-b4be-6e8405c0cb91">

・未入力エラー
<img width="1440" alt="スクリーンショット 2024-01-08 15 45 39" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/02d3fa78-4742-491b-b5d0-93cf75311c30">

・パスワードと確認用パスワードが一致しない場合のエラー
<img width="1440" alt="スクリーンショット 2024-01-08 15 41 29" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/6c056377-94b0-407f-8c6d-4551c019d1f9">

新規登録画面：
・新規登録画面のビュー
<img width="1438" alt="スクリーンショット 2024-01-08 13 19 23" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/ee3c4b82-59d0-49ce-aaab-7ba9803ad199">

・未入力エラー
<img width="1439" alt="スクリーンショット 2024-01-08 15 19 00" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/b4a5f217-98fd-44c9-b6b4-c6a5c167c475">

・使用済みメール設定時
<img width="1438" alt="スクリーンショット 2024-01-08 13 23 40" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/ac6ecfcd-afff-4ee4-a7af-fda81d36cc91">

・パスワードと確認用パスワードが一致しない場合のエラー
<img width="1440" alt="スクリーンショット 2024-01-08 15 29 52" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/4c6e741b-4150-4638-ab3a-a0420c79b816">

・パスワード文字数が8文字以下のとき
<img width="1440" alt="スクリーンショット 2024-01-08 15 30 30" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/5e99b5a2-872d-471a-8ec4-8c75ac4276da">


ユーザー情報更新画面：
・ユーザー情報登録画面
<img width="781" alt="スクリーンショット 2024-01-06 10 39 57" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/191a1943-9a98-4e73-8cc4-7206ac931fac">

・・ユーザー情報更新時
<img width="1433" alt="スクリーンショット 2024-01-06 10 40 23" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/50827c83-e425-4d16-8506-96213f6637d4">

・未入力エラー
<img width="1434" alt="スクリーンショット 2024-01-08 12 43 00" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/233f3340-7f49-498c-b351-4259b41f1fc8">

・メールアドレス重複
<img width="1435" alt="スクリーンショット 2024-01-08 12 37 05" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/65337f8e-0015-4f0c-8d65-2e3b3850d02b">


パスワード更新画面：
・パスワード更新画面
<img width="762" alt="スクリーンショット 2024-01-06 10 40 06" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/59ae8e51-a231-428d-a0cb-fe1698b6a7dd">

・未入力エラー
<img width="1437" alt="スクリーンショット 2024-01-08 12 44 09" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/59eae246-d9be-45c1-89b1-c85e78b9cac5">

・現在のパスワードの入力間違いエラー
<img width="1438" alt="スクリーンショット 2024-01-08 12 46 49" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/711c8787-583f-4fc6-9d3d-d246d626d392">

・パスワード文字数が8文字以下のとき
<img width="1439" alt="スクリーンショット 2024-01-08 12 55 56" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/c70c1ba6-fdf4-41bd-ba05-0e5e749311fb">

・新しいパスワードと確認用パスワードが一致しない場合のエラー
<img width="1429" alt="スクリーンショット 2024-01-08 12 50 39" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/e3f837e8-73cb-4161-a261-01208676de56">

・パスワードで英数字を含んでいない場合
<img width="1438" alt="スクリーンショット 2024-01-08 12 54 43" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/806bc25c-2711-4730-bbe2-3796317ad065">