### PR TITLE
ユーザー情報更新時の動的な未入力バリデーションとメールアドレス重複チェックを実装

### DIFF
--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -64,6 +64,12 @@ class CustomRegistrationsController < ApplicationController
     end
   end
 
+  def check_email
+    email = params[:email]
+    is_taken = User.where.not(id: current_user.id).exists?(email: email)
+    render json: { is_taken: is_taken }
+  end
+
   private
 
   # ユーザー情報関連のパラメータが提供されているか確認

--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -40,9 +40,7 @@ document.addEventListener('submit', function(event) {
 
 function validateAndHighlightInput(element ,sub_errorMessage, inputElement, event) {
   let menu_main_errorMessage = document.getElementById("main-menu-error");
-  console.log("きています。");
-  console.log(element);
-  console.log(inputElement);
+
   if (element.value === "" ) {
     event.preventDefault();
     menu_main_errorMessage.textContent = "⚠️未入力があります。";

--- a/app/javascript/user_validation.js
+++ b/app/javascript/user_validation.js
@@ -11,8 +11,12 @@ document.addEventListener('submit', function(event) {
   // 名前とメールアドレスの入力フィールドを取得
   const nameInput = document.querySelector('input[name="user[name]"]');
   const emailInput = document.querySelector('input[name="user[email]"]');
+
   // 入力バリデーションを実行し、失敗した場合はフォームの送信を阻止
-  if (!validateInput(nameInput) || !validateInput(emailInput)) {
+  let isNameValid = validateInput(nameInput);
+  let isEmailValid = validateInput(emailInput);
+  // 入力バリデーションを実行し、失敗した場合はフォームの送信を阻止
+  if (!isNameValid && !isEmailValid) {
     event.preventDefault();
     return;
   }
@@ -44,6 +48,7 @@ function validateInput(input) {
     createErrorMessage(input, "⚠️入力してください。");
     return false;
   }
+  input.style.backgroundColor = "";
   // 入力値が有効な場合、trueを返す
   return true;
 }

--- a/app/javascript/user_validation.js
+++ b/app/javascript/user_validation.js
@@ -15,6 +15,7 @@ document.addEventListener('submit', function(event) {
   // 入力バリデーションを実行し、失敗した場合はフォームの送信を阻止
   let isNameValid = validateInput(nameInput);
   let isEmailValid = validateInput(emailInput);
+
   // 入力バリデーションを実行し、失敗した場合はフォームの送信を阻止
   if (!isNameValid && !isEmailValid) {
     event.preventDefault();
@@ -25,10 +26,10 @@ document.addEventListener('submit', function(event) {
   event.preventDefault();
   checkEmailAvailability(emailInput.value)
     .then(isAvailable => {
-      if (isAvailable) {
-        // メールアドレスが重複していない場合、フォームを送信
+      if (isAvailable && isNameValid && isEmailValid) {
+        // メールアドレスが重複しておらず、他のバリデーションも通過した場合、フォームを送信
         event.target.submit();
-      } else {
+      } else if (!isAvailable) {
         // メールアドレスが重複している場合、エラーメッセージを表示
         createErrorMessage(emailInput, "⚠️メールアドレスはすでに使用されています。");
       }

--- a/app/javascript/user_validation.js
+++ b/app/javascript/user_validation.js
@@ -1,0 +1,81 @@
+// ドキュメントに 'submit' イベントリスナーを追加
+document.addEventListener('submit', function(event) {
+  // '更新' ボタン（idが 'update-user-submit'）の要素を取得
+  let updateUserSubmitButton = event.target.querySelector('#update-user-submit');
+  // '更新' ボタンが存在しない場合、処理を終了
+  if (!updateUserSubmitButton) return;
+
+  // 既存のエラーメッセージをクリア
+  clearErrorMessages();
+
+  // 名前とメールアドレスの入力フィールドを取得
+  const nameInput = document.querySelector('input[name="user[name]"]');
+  const emailInput = document.querySelector('input[name="user[email]"]');
+  // 入力バリデーションを実行し、失敗した場合はフォームの送信を阻止
+  if (!validateInput(nameInput) || !validateInput(emailInput)) {
+    event.preventDefault();
+    return;
+  }
+
+  // メールアドレスの重複チェックを非同期で行い、結果に応じて処理を行う
+  event.preventDefault();
+  checkEmailAvailability(emailInput.value)
+    .then(isAvailable => {
+      if (isAvailable) {
+        // メールアドレスが重複していない場合、フォームを送信
+        event.target.submit();
+      } else {
+        // メールアドレスが重複している場合、エラーメッセージを表示
+        createErrorMessage(emailInput, "⚠️メールアドレスはすでに使用されています。");
+      }
+    });
+});
+
+function clearErrorMessages() {
+  // 全てのエラーメッセージ要素を取得し、削除する
+  document.querySelectorAll('.error-message').forEach((element) => {
+    element.remove();
+  });
+}
+
+function validateInput(input) {
+  // 入力値が空の場合、エラーメッセージを表示し、falseを返す
+  if (input.value === "") {
+    createErrorMessage(input, "⚠️入力してください。");
+    return false;
+  }
+  // 入力値が有効な場合、trueを返す
+  return true;
+}
+
+function createErrorMessage(input, message) {
+  // エラーメッセージ要素を作成し、スタイルを設定
+  const errorMessage = document.createElement('div');
+  errorMessage.textContent = message;
+  errorMessage.classList.add('error-message');
+  errorMessage.style.color = 'red';
+  // エラーメッセージを入力フィールドの前に挿入
+  input.parentNode.insertBefore(errorMessage, input);
+  // エラーメッセージの背景色を設定
+  input.style.backgroundColor = "rgb(255, 184, 184)";
+}
+
+function checkEmailAvailability(email) {
+  // CSRFトークンを取得し、サーバーへのPOSTリクエストを行う
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+  // メールアドレスの重複をチェックするサーバーサイドのURL
+  const url = '/registrations/check_email';
+
+  // サーバーにメールアドレスの重複チェックをリクエスト
+  return fetch(url, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': token
+    },
+    body: JSON.stringify({ email: email })
+  })
+  .then(response => response.json())
+  .then(data => !data.is_taken); // メールアドレスが既に使用されていない場合、trueを返す
+}

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -12,15 +12,15 @@
     <%= form_with model: current_user, url: password_info_update_custom_registration_path, local: true, method: :patch do |f| %>
 
       <div class="registration-field">
-        <%= f.text_field :current_password, name: 'user[current_password]', autocomplete: "current_password", placeholder: "現在のパスワードを入力" %>
+        <%= f.text_field :current_password, name: 'user[current_password]', autocomplete: "current_password", placeholder: "現在のパスワードを入力", maxlength: 20 %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "新しいパスワードを入力" %>
+        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "新しいパスワードを入力", maxlength: 20 %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "もう一度新しいパスワードを入力" %>
+        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "もう一度新しいパスワードを入力", maxlength: 20 %>
       </div>
 
       <div class="registration-link">

--- a/app/views/custom_registrations/edit_user.html.erb
+++ b/app/views/custom_registrations/edit_user.html.erb
@@ -11,11 +11,11 @@
   <div class="registration-input">
     <%= form_with model: current_user, url: user_info_update_custom_registration_path, local: true, method: :patch do |f| %>
       <div class="registration-field">
-        <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "ユーザー名" %>
+        <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "ユーザー名", maxlength: 8 %>
       </div>
 
       <div class="registration-field">
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", maxlength: 254 %>
       </div>
 
       <div class="registration-link">

--- a/app/views/custom_registrations/edit_user.html.erb
+++ b/app/views/custom_registrations/edit_user.html.erb
@@ -23,11 +23,14 @@
       </div>
 
       <div class="registration-actions">
-        <%= f.submit "更新" %>
+        <%= f.submit "更新", id: "update-user-submit" %>
       </div>
+
     <% end %>
     <div class="registration-back-button">
       <%= button_to "戻る", root_path, class: "back-button", method: :get %>
     </div>
   </div>
 </div>
+
+<%= javascript_include_tag 'user_validation' %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,4 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin "nav_menu", to: "nav_menu.js", preload: true
 pin "checkbox_button_control", to: "checkbox_button_control.js", preload: true
 pin "menu_button_style_update", to: "menu_button_style_update.js", preload: true
+pin "user_validation", to: "user_validation.js", preload: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,6 @@ Rails.application.routes.draw do
   post '/cart_items/:id/increment', to: 'cart_items#increment', as: 'cart_item_increment'
   # カートアイテムの数量を減らす
   post '/cart_items/:id/decrement', to: 'cart_items#decrement', as: 'cart_item_decrement'
-
   post '/shopping_lists/:id/toggle_check', to: 'shopping_lists#toggle_check', as: 'shopping_list_toggle_check'
 
   resources :completed_menus do
@@ -40,7 +39,9 @@ Rails.application.routes.draw do
     get 'users/sessions', to: 'custom_sessions#destroy', as: :destroy_user_custom_session
     get 'registrations/edit_user', to: 'custom_registrations#edit_user', as: :edit_user_custom_registration
     get 'registrations/edit_password', to: 'custom_registrations#edit_password', as: :edit_password_user_custom_registration
-    # patch 'registrations/update', to: 'custom_registrations#update', as: :update_user_custom_registration
+
+    # ユーザー情報編集時にメールアドレスの重複チェック機能をAjaxで追加するためのルーチング
+    post 'registrations/check_email', to: 'custom_registrations#check_email'
 
     # ユーザー情報更新用のルーティング
     patch 'registrations/update_user_info', to: 'custom_registrations#user_info_update', as: :user_info_update_custom_registration


### PR DESCRIPTION
目的：
ユーザーが情報更新をスムーズに行えるように、フォームのバリデーション機能を充実させることです。

内容：
・未入力フィールドに対する動的なバリデーションを実装
・メールアドレスの重複チェック機能を追加
・編集フォームの最大文字数を設定

エラー時の画面：
・２つのフォームが未入力の場合
<img width="798" alt="スクリーンショット 2024-01-09 1 06 54" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/8cbab642-ddbd-4f75-91b8-e05c96a60ae6">

・ユーザー名のフォームが未入力でメールアドレスが重複している場合
<img width="765" alt="スクリーンショット 2024-01-09 1 08 01" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/923c574b-b6d6-4331-b8a1-41503aa13c6c">

・「ユーザー名のフォームが未入力でメールアドレスが重複している場合」からユーザー名を入力してsubmitした場合
<img width="776" alt="スクリーンショット 2024-01-09 1 07 45" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/41ec0158-e0b8-4e58-b10b-6892b2052660">

・「ユーザー名のフォームが未入力でメールアドレスが重複している場合」からメールアドレスを入力してsubmitした場合
<img width="754" alt="スクリーンショット 2024-01-09 1 40 32" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/26bddd50-cf24-4433-9a78-e57bf40243bc">

