### PR TITLE
Develop/menu registration form

### DIFF
--- a/app/assets/stylesheets/edit_custom_registration.scss
+++ b/app/assets/stylesheets/edit_custom_registration.scss
@@ -8,6 +8,14 @@
     margin-bottom: 30px;
   }
 
+  .registration-instructions p {
+    margin-bottom: 0px
+  }
+
+  .password-instructions p {
+    margin-top: 0px
+  }
+
   .registration-instructions{
     @include form-instructions;
   }

--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -70,6 +70,12 @@ class CustomRegistrationsController < ApplicationController
     render json: { is_taken: is_taken }
   end
 
+  # パスワード更新画面で入力されたパスワードがあっているか検証
+  def validate_current_password
+    is_valid = current_user.valid_password?(params[:current_password])
+    render json: { is_valid: is_valid }
+  end
+
   private
 
   # ユーザー情報関連のパラメータが提供されているか確認

--- a/app/javascript/password_validation.js
+++ b/app/javascript/password_validation.js
@@ -1,0 +1,113 @@
+document.addEventListener('submit', function(event) {
+  let updatePasswordSubmitButton = event.target.querySelector('#update-password-submit');
+  if (!updatePasswordSubmitButton) return;
+
+  // フォームのバリデーション状態を追跡する変数
+  let PasswordIsValid = true;
+
+  clearErrorMessages();
+
+  const currentPasswordInput = document.querySelector('input[name="user[current_password]"]');
+  const newPasswordInput = document.querySelector('input[name="user[password]"]');
+  const newPasswordConfirmationInput = document.querySelector('input[name="user[password_confirmation]"]');
+
+  // 未入力のフィールドがあるか確認し、あればエラーメッセージを表示
+  [currentPasswordInput, newPasswordInput, newPasswordConfirmationInput].forEach(input => {
+    if (!input.value.trim()) {
+      createErrorMessage(input, "⚠️入力してください。");
+      input.style.backgroundColor = "rgb(255, 184, 184)";
+      event.preventDefault();
+    }
+  });
+
+  // currentPasswordInputにエラーのスタイルが適用されている場合、現在のパスワードの検証をスキップ
+  if (currentPasswordInput.style.backgroundColor === "rgb(255, 184, 184)") {
+    PasswordIsValid = false;
+  }
+
+  // 現在のパスワードの検証
+  if (PasswordIsValid) {
+    validateCurrentPassword(currentPasswordInput, event);
+  }
+
+  // 新しいパスワードの長さとフォーマットを検証
+  if (newPasswordInput.value.trim() !== '' && !isPasswordValid(newPasswordInput.value)) {
+    createErrorMessage(newPasswordInput, "⚠️8文字以上、大小英字、数字、特殊文字を含んでください。");
+    newPasswordInput.style.backgroundColor = "rgb(255, 184, 184)";
+    event.preventDefault();
+    PasswordIsValid = false;
+  }
+
+  // 新しいパスワードが未入力の場合、確認用パスワードにエラーメッセージを表示
+  if (!newPasswordInput.value.trim() && newPasswordConfirmationInput.value.trim()) {
+    createErrorMessage(newPasswordConfirmationInput, "⚠️新しいパスワードと内容が異なります。");
+    newPasswordConfirmationInput.style.backgroundColor = "rgb(255, 184, 184)";
+    event.preventDefault();
+  }
+
+  // 「newPasswordInput」または「newPasswordConfirmationInput」のいずれかがすでにエラーの場合は検証をスキップ
+  if ([newPasswordInput, newPasswordConfirmationInput].some(input => input.style.backgroundColor === "rgb(255, 184, 184)")) return;
+
+  // 新しいパスワードと確認用パスワードが一致するか検証
+  if (newPasswordInput.value !== newPasswordConfirmationInput.value) {
+    createErrorMessage(newPasswordConfirmationInput, "⚠️新しいパスワードと一致しません。");
+    newPasswordConfirmationInput.style.backgroundColor = "rgb(255, 184, 184)";
+    event.preventDefault();
+  }
+});
+
+function clearErrorMessages() {
+  document.querySelectorAll('.error-message').forEach(element => {
+    element.remove();
+  });
+  document.querySelectorAll('input').forEach(input => {
+    input.style.backgroundColor = "";
+  });
+}
+
+function createErrorMessage(input, message) {
+  const errorMessage = document.createElement('div');
+  errorMessage.textContent = message;
+  errorMessage.classList.add('error-message');
+  errorMessage.style.color = 'red';
+  input.parentNode.insertBefore(errorMessage, input);
+}
+
+function validateCurrentPassword(input, callback) {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+  const url = '/registrations/validate_current_password';
+
+  fetch(url, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': token
+    },
+    body: JSON.stringify({ current_password: input.value })
+  })
+  .then(response => response.json())
+  .then(data => {
+    if (!data.is_valid) {
+      createErrorMessage(input, "⚠️現在のパスワードが間違っています。");
+      input.style.backgroundColor = "rgb(255, 184, 184)";
+      event.preventDefault();
+    }
+  })
+  .catch(error => {
+    // エラー処理
+    event.preventDefault();
+    formIsValid = false;
+  });
+}
+
+function isPasswordValid(password) {
+  // まずパスワードの長さを検証
+  if (password.length < 8) {
+    return false;
+  }
+
+  // 次に正規表現を使ってパスワードの形式を検証
+  const regex = /^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)(?=.*?[\W_])[a-zA-Z\d\W_]+$/;
+  return regex.test(password);
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   # パスワードが変更された場合、または新規作成の場合に検証する
   validates :password, length: { minimum: 8, too_short: "パスワードは最低%{count}文字必要です。" }, if: :password_change_or_new_record?
   validates :password, confirmation: { message: "新しいパスワードと確認用パスワードが一致しません。" },
-    format: { with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)(?=.*?[\W_])[a-zA-Z\d\W_]+\z/, message: "パスワードは8文字以上、大小英字、数字、特殊文字を含んでください。" }, if: :password_change_or_new_record?
+    format: { with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)(?=.*?[\W_])[a-zA-Z\d\W_]+\z/, message: "パスワードは8文字以上、大小英字、数字、記号を含んでください。" }, if: :password_change_or_new_record?
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,20 +3,25 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
 
   validates :name, presence: { message: "ユーザー名は必須です。" },
-    length: { maximum: 8, too_long: "ユーザー名は最大%{count}文字までです。" }
+    length: { maximum: 8, too_long: "ユーザー名は最大%{count}文字までです。" },
+    format: { with: /\A[a-zA-Z0-9_\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF]+\z/,
+    message: "使用できるのは英数字、アンダースコア、日本語です。" }, if: :user_info_change_or_new_record?
+
+  # メールアドレスのバリデーション
   validates :email, presence: { message: "メールアドレスは必須です" },
     uniqueness: { case_sensitive: false, message: "このメールアドレスは既に使用されています。" },
-    length: { maximum: 254, too_long: "メールアドレスは最大%{count}文字までです。" }
+    length: { maximum: 254, too_long: "メールアドレスは最大%{count}文字までです。" },
+    format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i, message: "メールアドレスの形式が不正です" }, if: :user_info_change_or_new_record?
 
   # パスワードのバリデーションを新規作成と更新の両方で適用
   # パスワードが変更された場合、または新規作成の場合に検証する
-  validates :password, length: { minimum: 8, too_short: "パスワードは最低%{count}文字必要です。" }, if: :password_present?
+  validates :password, length: { minimum: 8, too_short: "パスワードは最低%{count}文字必要です。" }, if: :password_change_or_new_record?
   validates :password, confirmation: { message: "新しいパスワードと確認用パスワードが一致しません。" },
-    format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: "パスワードは英数字を含む必要があります。" }, if: :password_present?
+    format: { with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)(?=.*?[\W_])[a-zA-Z\d\W_]+\z/, message: "パスワードは8文字以上、大小英字、数字、特殊文字を含んでください。" }, if: :password_change_or_new_record?
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  attr_accessor :current_password
+  attr_accessor :current_password, :user_info_change, :password_change, :new_record
 
   has_many :menu_users, dependent: :destroy
   has_many :menus, through: :menu_users
@@ -27,7 +32,11 @@ class User < ApplicationRecord
 
   private
 
-  def password_present?
-    password.present?
+  def user_info_change_or_new_record?
+    user_info_change || new_record
+  end
+
+  def password_change_or_new_record?
+    password_change || new_record
   end
 end

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -14,15 +14,18 @@
       <%= f.hidden_field :password_change, value: true %>
 
       <div class="registration-field">
-        <%= f.text_field :current_password, name: 'user[current_password]', autocomplete: "current_password", placeholder: "現在のパスワードを入力" %>
+        <div class="error-message"></div>
+        <%= f.text_field :current_password, name: 'user[current_password]', autocomplete: "off", placeholder: "現在のパスワードを入力" %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "新しいパスワードを入力" %>
+        <div class="error-message"></div>
+        <%= f.password_field :password, name: 'user[password]', autocomplete: "off", placeholder: "新しいパスワードを入力" %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "もう一度新しいパスワードを入力" %>
+        <div class="error-message"></div>
+        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "off", placeholder: "もう一度新しいパスワードを入力" %>
       </div>
 
       <div class="registration-link">

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -5,22 +5,24 @@
   </div>
 
   <div class="registration-instructions">
-    <p>パスワード変更後、新しいパスワードで再ログインが必要です。</p>
+    <p>更新後、新しいパスワードで再ログインが必要です。<br>
+    ※パスワード: 8文字以上、大小英字、数字、特殊文字を含む</p>
   </div>
 
   <div class="registration-input">
     <%= form_with model: current_user, url: password_info_update_custom_registration_path, local: true, method: :patch do |f| %>
+      <%= f.hidden_field :password_change, value: true %>
 
       <div class="registration-field">
-        <%= f.text_field :current_password, name: 'user[current_password]', autocomplete: "current_password", placeholder: "現在のパスワードを入力", maxlength: 20 %>
+        <%= f.text_field :current_password, name: 'user[current_password]', autocomplete: "current_password", placeholder: "現在のパスワードを入力" %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "新しいパスワードを入力", maxlength: 20 %>
+        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "新しいパスワードを入力" %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "もう一度新しいパスワードを入力", maxlength: 20 %>
+        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "もう一度新しいパスワードを入力" %>
       </div>
 
       <div class="registration-link">
@@ -28,7 +30,7 @@
       </div>
 
       <div class="registration-actions">
-        <%= f.submit "更新" %>
+        <%= f.submit "更新", id: "update-password-submit" %>
       </div>
     <% end %>
     <div class="registration-back-button">
@@ -36,3 +38,5 @@
     </div>
   </div>
 </div>
+
+<%= javascript_include_tag 'password_validation' %>

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -6,7 +6,7 @@
 
   <div class="registration-instructions">
     <p>更新後、新しいパスワードで再ログインが必要です。<br>
-    ※パスワード: 8文字以上、大小英字、数字、特殊文字を含む</p>
+    ※パスワード: 8文字以上、大小英字、数字、記号を含む</p>
   </div>
 
   <div class="registration-input">

--- a/app/views/custom_registrations/new.html.erb
+++ b/app/views/custom_registrations/new.html.erb
@@ -10,6 +10,8 @@
 
   <div class="registration-input">
     <%= form_with url: user_custom_registration_path, local: true do |f| %>
+      <%= f.hidden_field :new_record, value: true %>
+
       <div class="registration-field">
         <%= f.text_field :name, name: 'user[name]', autofocus: true, autocomplete: "name", placeholder: "ユーザー名", maxlength: 8 %>
       </div>
@@ -19,11 +21,11 @@
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "パスワード（最低8桁の英数字を含む）", maxlength: 20 %>
+        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "パスワード（最低8桁の英数字を含む）", maxlength: 100 %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "確認用パスワード", maxlength: 20 %>
+        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "確認用パスワード", maxlength: 100 %>
       </div>
 
       <div class="registration-actions">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,3 +9,5 @@ pin "nav_menu", to: "nav_menu.js", preload: true
 pin "checkbox_button_control", to: "checkbox_button_control.js", preload: true
 pin "menu_button_style_update", to: "menu_button_style_update.js", preload: true
 pin "user_validation", to: "user_validation.js", preload: true
+pin "password_validation", to: "password_validation.js", preload: true
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
 
     # ユーザー情報編集時にメールアドレスの重複チェック機能をAjaxで追加するためのルーチング
     post 'registrations/check_email', to: 'custom_registrations#check_email'
+    # ユーザーの現在のパスワードが正しいかを検証するためのAjaxリクエストを処理するためのルーティング
+    post 'registrations/validate_current_password', to: 'custom_registrations#validate_current_password'
 
     # ユーザー情報更新用のルーティング
     patch 'registrations/update_user_info', to: 'custom_registrations#user_info_update', as: :user_info_update_custom_registration


### PR DESCRIPTION
目的：
システムのセキュリティとユーザー体験の向上が目的です。

内容：
・パスワード更新ページに動的バリデーションの追加
・バックエンドで未入力バリデーションの設定
・フォーム送信情報に基づくバリデーションの区別化

行なったテスト：
パスワードの形式のテスト（エラー："パスワードは8文字以上、大小英字、数字、特殊文字を含んでください。"）
・大小英字、数字、特殊文字を含む："Password1!"（有効）
<img width="712" alt="スクリーンショット 2024-01-15 16 56 34" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/55a296eb-2ed5-4e46-a0f5-20bd767b5b56">

・大文字を含まない："password1!"（エラー）
<img width="718" alt="スクリーンショット 2024-01-15 16 56 50" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/48d5fbb5-67a2-4af7-a296-492c71d3df28">

・小文字を含まない："PASSWORD1!"（エラー）
<img width="717" alt="スクリーンショット 2024-01-15 16 57 04" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/a95f1e92-7c13-4002-a8ae-4b41cc87e7ec">

・数字を含まない："Password!"（エラー）
<img width="717" alt="スクリーンショット 2024-01-15 16 57 20" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/78dfdf9c-a85a-4f3f-8a27-a3b60930e8ad">

・記号を含まない："Password1"（エラー）
<img width="711" alt="スクリーンショット 2024-01-15 16 57 32" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/554b0afb-2266-43b4-88f7-63043a440530">

・パスワードの確認一致のテスト（エラー："新しいパスワードと一致しません。"）
パスワードと確認用が一致する：パスワード："Password1!"、確認用："Password1!"（有効）
<img width="718" alt="スクリーンショット 2024-01-15 17 00 11" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/e540a4d2-5126-4e83-b339-b7e483129405">

・パスワードと確認用が一致しない：パスワード："Password1!"、確認用："Password2!"（エラー）
<img width="714" alt="スクリーンショット 2024-01-15 17 00 21" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/960d1ad1-a749-4fc1-a6ae-ceee83c9161b">

・すべて未入力の場合
<img width="713" alt="スクリーンショット 2024-01-15 17 01 21" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/dbdc233b-793e-4f25-b1ab-830fae9385be">

・現在パスだけ未入力
<img width="720" alt="スクリーンショット 2024-01-15 17 04 58" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/34897607-2257-4d82-80db-f3ea2917b444">

・新パスだけ未入力
<img width="713" alt="スクリーンショット 2024-01-15 17 05 57" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/68ac58f9-bed1-4edd-abcd-b526f7ee1bd0">

・確認パスだけ未入力
<img width="717" alt="スクリーンショット 2024-01-15 17 06 47" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/c9a3abb2-06db-4e00-86d1-c3999e529f45">

・現在パスが違う（submit時）
<img width="1438" alt="スクリーンショット 2024-01-15 17 01 56" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/04186f5e-7d81-4f04-8c1c-4f47d950f09a">

・現在のパスワードが正しく、新しいパスワードと確認用パスワードが未入力の場合
<img width="716" alt="スクリーンショット 2024-01-15 17 03 26" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/3975d114-8d45-4bd1-878f-0f2b60eb54dc">

・現在パス未入力、新パスが規則に適合しない
<img width="713" alt="スクリーンショット 2024-01-15 19 37 07" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/2d80c132-1dc7-4bcd-bc9b-3b2fcec1db57">

・現在パスが正しい、新パスと確認パスが一致しない
<img width="700" alt="スクリーンショット 2024-01-15 19 38 37" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/fb9dafe8-6312-4092-8632-40575190e8c2">

・現在パスが正しい、新パスが未入力で、確認パスが規則に適合（また不適合）の場合
<img width="707" alt="スクリーンショット 2024-01-15 19 39 36" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/bda5fdc2-c6de-4cb4-ab71-22dc9f2e89d3">


