### PR TITLE
確認メール送信後の画面の実装とスタイル調整

### DIFF
--- a/app/assets/stylesheets/show_resend_confirmation_form.scss
+++ b/app/assets/stylesheets/show_resend_confirmation_form.scss
@@ -1,0 +1,76 @@
+@import 'shared/styles';
+
+.resend-registration-container{
+  @include form-container;
+  @media screen and (max-width: 900px) {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: auto;
+    padding: 20px 40px;
+    box-sizing: border-box;
+    margin-top: 100px;
+    margin-bottom: 60px;
+  }
+
+  .resend-registration-message{
+    @include form-title;
+  }
+
+  .resend-registration-message h1{
+    margin-top: 40px;
+    margin-bottom: 0px;
+    @media screen and (max-width: 600px) {
+      margin-bottom: 0px;
+    }
+  }
+
+  .resend-registration-email{
+    font-size: 20px;
+    text-align: center;
+    margin-bottom: 10px;
+  }
+
+  .resend-registration-explanation p{
+    font-size: 20px;
+    text-align: center;
+    margin: 0px;
+    @media screen and (max-width: 600px) {
+      font-size: 14px;
+    }
+  }
+
+  .resend-registration-sub-explanation-title{
+    font-size: 15px;
+    font-weight: bold;
+    @media screen and (max-width: 600px) {
+      font-size: 16px;
+    }
+  }
+
+  .resend-registration-sub-explanation{
+    width: 60%;
+    font-size: 15px;
+    text-align: center;
+    background-color: rgba(211, 211, 211, 0.7); /* 灰色で透明度0.7 */
+    border-radius: 8px;
+    padding: 15px;
+    margin: 10px 0;
+    @media screen and (max-width: 1150px) {
+      font-size: 10px;
+      width: 75%;
+    }
+  }
+
+  .resend-registration-instruction{
+    font-size: 13px;
+    margin-bottom: 10px;
+    color: red;
+    @media screen and (max-width: 600px) {
+      font-size: 10px;
+    }
+  }
+
+}

--- a/app/controllers/custom_confirmations_controller.rb
+++ b/app/controllers/custom_confirmations_controller.rb
@@ -1,5 +1,19 @@
 class CustomConfirmationsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:custom_confirm]
+  skip_before_action :authenticate_user!, only: [:custom_confirm, :show_resend_confirmation_form]
+
+  def show_resend_confirmation_form
+    # user_idが送信された場合の処理
+    if params[:user_id].present?
+      user = User.find_by(id: params[:user_id])
+      @user_email = user.email
+
+    # user_idが送信されていない場合の処理
+    else
+      redirect_to root_path
+    end
+
+
+  end
 
   def custom_confirm
     # confirmation_tokenを使ってユーザーを検索

--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -16,7 +16,7 @@ class CustomRegistrationsController < ApplicationController
     end
 
     if user.save
-      set_flash_and_redirect(:notice, "登録したメールアドレスに確認メールを送信しました。", root_path)
+      redirect_to show_resend_confirmation_form_path(user_id: user.id)
     else
       set_flash_and_redirect(:error, set_validation_error(user), new_user_custom_registration_path)
     end

--- a/app/views/custom_confirmations/show_resend_confirmation_form.html.erb
+++ b/app/views/custom_confirmations/show_resend_confirmation_form.html.erb
@@ -1,0 +1,37 @@
+<div class="resend-registration-container">
+
+  <div class="resend-registration-message">
+    <h1>確認メールを送付完了</h1>
+  </div>
+
+  <div class="resend-registration-email">
+    <p>登録されたメールアドレス<br>
+    <%= @user_email %></p>
+  </div>
+
+  <div class="resend-registration-explanation">
+    <p>
+      メールに記載されたリンクへアクセスし、<br>
+      認証を完了してください。
+    </p>
+  </div>
+
+  <div class="resend-registration-instruction">
+    <p>※URLの有効期限は24時間です</p>
+  </div>
+
+  <div class="resend-registration-sub-explanation">
+
+    <div class="resend-registration-sub-explanation-title">
+      <p>メールを確認できない場合</p>
+    </div>
+
+    <p>
+      ・迷惑メールフォルダに入っていないか<br>
+      ・メールアドレスに入力の誤りがないか<br>
+    </p>
+    <p>※メールアドレスに誤りがあった場合は<br>
+    <%= link_to '（再登録してください）', new_user_custom_registration_path %></p>
+  </div>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
   devise_for :users
   devise_scope :user do
     get 'users/confirmation/custom_confirm', to: 'custom_confirmations#custom_confirm', as: :custom_user_confirmation
+    get 'users/confirmation/resend', to: 'custom_confirmations#show_resend_confirmation_form', as: :show_resend_confirmation_form
+
     get 'users/registration', to: 'custom_registrations#new', as: :new_user_custom_registration
     post 'users/registration', to: 'custom_registrations#create', as: :user_custom_registration
     get 'users/session', to: 'custom_sessions#new', as: :new_user_custom_session


### PR DESCRIPTION
目的：
ユーザーが確認メールの送信状況を明確に把握できるように、メール送信後の画面を整備します。

内容：
・確認メール送信後の画面を新規作成

<img width="1440" alt="スクリーンショット 2024-01-20 23 04 40" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/21635cd2-ea39-46f3-99fa-65d3be300239">
