### PR TITLE
ユーザー名のバリデーションを緩和し、英数字のみを許可しました（最小2字、最大15字）

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
 
   validates :name, presence: { message: "ユーザー名は必須です。" },
-  length: { minimum: 8, too_short: "ユーザー名は最小%{count}文字必要です。", maximum: 30, too_long: "ユーザー名は最大%{count}文字までです。" },
-  format: { with: /\A[a-zA-Z0-9_\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF]+\z/, message: "英数字、アンダースコア、日本語のみ使用できます。" }, if: :user_info_change_or_new_record?
+  length: { minimum: 2, too_short: "ユーザー名は最低%{count}文字必要です。", maximum: 15, too_long: "ユーザー名は最大%{count}文字までです。" },
+  format: { with: /\A[a-zA-Z0-9]+\z/, message: 'ユーザー名は英数字のみが使用できます' }, if: :user_info_change_or_new_record?
 
   # メールアドレスのバリデーション
   validates :email, presence: { message: "メールアドレスは必須です" },

--- a/app/views/custom_registrations/new.html.erb
+++ b/app/views/custom_registrations/new.html.erb
@@ -13,19 +13,19 @@
       <%= f.hidden_field :new_record, value: true %>
 
       <div class="registration-field">
-        <%= f.text_field :name, name: 'user[name]', autofocus: true, autocomplete: "name", placeholder: "ユーザー名", maxlength: 8 %>
+        <%= f.text_field :name, name: 'user[name]', autofocus: true, autocomplete: "name", placeholder: "ユーザー名（2〜15文字、英数字）" %>
       </div>
 
       <div class="registration-field">
-        <%= f.email_field :email, name: 'user[email]', autofocus: true, autocomplete: "email", placeholder: "メールアドレス", maxlength: 254 %>
+        <%= f.email_field :email, name: 'user[email]', autofocus: true, autocomplete: "email", placeholder: "メールアドレス" %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "パスワード（最低8桁の英数字を含む）", maxlength: 100 %>
+        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "パスワード（8文字以上、英数記号含む）" %>
       </div>
 
       <div class="registration-field">
-        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "確認用パスワード", maxlength: 100 %>
+        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "確認用パスワード" %>
       </div>
 
       <div class="registration-actions">

--- a/app/views/custom_sessions/new.html.erb
+++ b/app/views/custom_sessions/new.html.erb
@@ -11,10 +11,10 @@
   <div class="session-input">
     <%= form_with url: user_custom_session_path, local: true, data: { turbo: false } do |f| %>
       <div class="session-field">
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", maxlength: 254 %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス" %>
       </div>
       <div class="session-field">
-        <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード（最低8桁の英数字を含む）", maxlength: 20 %>
+        <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード（8文字以上、英数記号含む）" %>
       </div>
       <div class="session-actions">
         <%= f.submit "ログイン" %>


### PR DESCRIPTION
目的：
ユーザー名設定の柔軟性を高め、利便性を向上させることです。

内容：
・ユーザー名の最小文字数を8文字から2文字に緩和
・ユーザー名の最大文字数を30文字から15文字に変更
・ユーザー名の許容文字種を英数字のみに限定


エラーメッセージ（最低2文字以上）：
<img width="1440" alt="スクリーンショット 2024-01-21 13 36 06" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/6bcf3c76-ea72-4cf2-8afd-bba3e07d9809">

エラーメッセージ（最大15文字以内）：
<img width="1410" alt="スクリーンショット 2024-01-21 13 34 20" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/693a880b-53c3-4ac5-9112-2562bb19ffc1">
