### PR TITLE
メールアドレス変更検証機能を実装し、メールテキストを修正

### DIFF
--- a/app/controllers/custom_confirmations_controller.rb
+++ b/app/controllers/custom_confirmations_controller.rb
@@ -29,6 +29,22 @@ class CustomConfirmationsController < ApplicationController
       return
     end
 
+    # メールアドレス更新の場合
+    if user.unconfirmed_email.present?
+      user.email = user.unconfirmed_email
+      user.unconfirmed_email = nil
+      user.confirmation_token = nil
+
+      # 確認メール送信をスキップ
+      user.skip_reconfirmation!
+
+      user.save
+
+      flash[:notice] = "メールアドレスが更新されました。"
+      redirect_to edit_email_custom_registration_path
+      return
+    end
+
     # ユーザーが既に認証済みの場合
     if user.confirmed?
       flash[:notice] = "すでに認証は完了しています。ログインしてください。"

--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -6,6 +6,7 @@ class CustomRegistrationsController < ApplicationController
     @user = User.new
   end
 
+
   def create
     #user情報を格納する
     user = User.new(registration_params)
@@ -22,11 +23,14 @@ class CustomRegistrationsController < ApplicationController
     end
   end
 
+
   def edit_user
   end
 
+
   def edit_password
   end
+
 
   def email_update
     if params[:user][:email].blank?
@@ -34,14 +38,22 @@ class CustomRegistrationsController < ApplicationController
       return
     end
 
-    # ユーザー情報の更新
-    if current_user.update(registration_params)
-      set_flash_and_redirect(:notice, "ユーザー情報を更新しました。", edit_email_custom_registration_path)
-    else
-      set_flash_and_redirect(:error, set_validation_error(current_user), edit_email_custom_registration_path)
+    # 入力されたメールアドレスが現在のメールアドレスと同じかどうかをチェック
+    if params[:user][:email] == current_user.email
+      set_flash_and_redirect(:error, "登録済みのアドレスです。", edit_email_custom_registration_path)
       return
     end
+
+    # ユーザー情報の更新
+    if current_user.update(registration_params)
+      # 新しいメールアドレスに確認メールを送信
+      current_user.send_reconfirmation_instructions
+      set_flash_and_redirect(:notice, "メールアドレス更新の確認メールを送信しました。", edit_email_custom_registration_path)
+    else
+      set_flash_and_redirect(:error, set_validation_error(current_user), edit_email_custom_registration_path)
+    end
   end
+
 
   def password_info_update
     if password_info_missing?

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,12 +2,14 @@
 
 <p>この度は、メールアドレスのご本人確認をお願いいたします。以下のリンクをクリックして、認証手続きを完了させてください。</p>
 
-<p><%= link_to 'メールアドレスを認証する', custom_user_confirmation_url(confirmation_token: @token) %></p>
+<p><%= link_to 'メールアドレスを認証する', custom_user_confirmation_url(confirmation_token: @token) %></p><br>
 
-<p>もし誤ったメールアドレスを登録された場合、または上記リンクが機能しない場合には、お手数ですが再度新規登録をお願いします。</p>
+<p style="margin: 0; padding: 0;">新規登録の方へ：</p>
+<p style="margin: 0; padding: 0;">・メールアドレスの誤登録やリンク不具合の際は、再登録をお願いします。</p><br>
 
-<p>ご注意：</p>
-<ul>
-  <li>このリンクはお送りしたメールが届いてから24時間有効です。</li>
-  <li>24時間を過ぎると、リンクは無効となりますので、お早めにご対応ください。</li>
-</ul>
+<p style="margin: 0; padding: 0;">メールアドレス更新の方へ：</p>
+<p style="margin: 0; padding: 0;">・メールアドレスの認証前であれば、既存のアドレスでのログインは引き続き可能です。</p><br>
+
+<p style="margin: 0; padding: 0;">ご注意：</p>
+<p style="margin: 0; padding: 0;">・このリンクはお送りしたメールが届いてから24時間有効です。</p>
+<p style="margin: 0; padding: 0;">・24時間を過ぎると、リンクは無効となりますので、お早めにご対応ください。</p>


### PR DESCRIPTION
目的：
メールアドレスの不正利用を防ぎ、変更プロセスを安全に実施することです。

内容：
・メールアドレス変更時の検証プロセスを実装
・メールテキストの内容を見直し、更新

メール文：
<img width="736" alt="スクリーンショット 2024-01-23 3 34 26" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/4bea0daf-0ca3-4697-af31-364e04bb2a13">

メール送信時：
<img width="1440" alt="スクリーンショット 2024-01-23 3 35 02" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/ee9066b3-bb7b-4b11-ab5c-9ebdf494fbd2">

メール認証時：
<img width="1437" alt="スクリーンショット 2024-01-23 3 42 10" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/637fcf5b-6a71-4333-abba-230771e05f23">
