### PR TITLE
メールアドレス認証の重複送信不具合を修正

### DIFF
--- a/app/controllers/custom_confirmations_controller.rb
+++ b/app/controllers/custom_confirmations_controller.rb
@@ -36,9 +36,6 @@ class CustomConfirmationsController < ApplicationController
       user.confirmation_token = nil
 
       # 確認メール送信をスキップ
-      user.skip_confirmation_notification!
-
-      # 確認プロセスの手動実行
       user.skip_reconfirmation!
 
       user.save

--- a/app/controllers/custom_confirmations_controller.rb
+++ b/app/controllers/custom_confirmations_controller.rb
@@ -36,6 +36,9 @@ class CustomConfirmationsController < ApplicationController
       user.confirmation_token = nil
 
       # 確認メール送信をスキップ
+      user.skip_confirmation_notification!
+
+      # 確認プロセスの手動実行
       user.skip_reconfirmation!
 
       user.save

--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -45,9 +45,8 @@ class CustomRegistrationsController < ApplicationController
     end
 
     # ユーザー情報の更新
+    # 新しいメールアドレスに確認メールを送信
     if current_user.update(registration_params)
-      # 新しいメールアドレスに確認メールを送信
-      current_user.send_reconfirmation_instructions
       set_flash_and_redirect(:notice, "メールアドレス更新の確認メールを送信しました。", edit_email_custom_registration_path)
     else
       set_flash_and_redirect(:error, set_validation_error(current_user), edit_email_custom_registration_path)


### PR DESCRIPTION
目的：
メールアドレス認証の不具合を改善し、確実な処理を実現することです。

内容：
・メールアドレス認証時の重複送信問題を解決
・メール送信ロジックの最適化を実施