### PR TITLE
ホーム画面の献立選択ボタン統合とナビゲーションの改善

### DIFF
--- a/app/assets/stylesheets/menu/menu_list.scss
+++ b/app/assets/stylesheets/menu/menu_list.scss
@@ -8,13 +8,47 @@
     text-align: center;
   }
 
-  .original-menu-heading {
-    @extend .menu-heading;
+  .menu-list-container{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .main-menu-list-heading,
+    .menu-list-heading {
+      color: black;
+      margin-top: 10px;
+      margin-bottom: 30px;
+      margin-right: 15px;
+      margin-left: 15px;
+      cursor: pointer;
+      @media screen and (max-width: 600px) {
+        margin-right: 10px;
+        margin-left: 10px;
+      }
+    }
+
+    .main-menu-list-heading {
+      font-size: 30px;
+      font-weight: bold;
+      text-decoration: underline;
+      color: black;
+      @media screen and (max-width: 600px) {
+        font-size: 20px;
+      }
+    }
+
+    .menu-list-heading{
+      font-size: 25px;
+      text-decoration: none;
+      opacity: 0.5;
+      @media screen and (max-width: 600px) {
+        font-size: 15px;
+      }
+    }
   }
 
-  .menu-list-heading {
-    @extend .menu-heading;
-  }
+
+
 
   .menus_list {
     .original-menu-button{

--- a/app/assets/stylesheets/user-index.scss
+++ b/app/assets/stylesheets/user-index.scss
@@ -102,14 +102,8 @@
       cursor: pointer;
     }
 
-    /* ボタンの背景色クラス */
-    .bg-custom-menu {
-      background-color: #555;
-      @include hover-background;
-    }
-
     .bg-standard-menu {
-      background-color: #777;
+      background-color: #1f1f1f;
       @include hover-background(#dadada);
     }
 

--- a/app/views/menus/custom_menus.html.erb
+++ b/app/views/menus/custom_menus.html.erb
@@ -2,7 +2,10 @@
 <%= render 'shared/back_button' %>
 
 <div class="menus-container">
-  <h3 class="original-menu-heading">オリジナル献立</h3>
+  <nav class="menu-list-container">
+    <%= link_to "サンプル献立", sample_menus_path, class: "menu-list-heading", method: :get %>
+    <%= link_to "オリジナル献立", user_custom_menus_path(current_user), class: "main-menu-list-heading", method: :get %>
+  </nav>
 
   <div class="menus_list">
     <%= button_to "オリジナル献立作成", new_user_menu_path(current_user.id), class: "original-menu-button", method: :get %>

--- a/app/views/menus/sample_menus.html.erb
+++ b/app/views/menus/sample_menus.html.erb
@@ -2,7 +2,11 @@
 <%= render 'shared/back_button' %>
 
 <div class="menus-container">
-  <h3 class="menu-list-heading">サンプル献立</h3>
+
+  <nav class="menu-list-container">
+    <%= link_to "サンプル献立", sample_menus_path, class: "main-menu-list-heading", method: :get %>
+    <%= link_to "オリジナル献立", user_custom_menus_path(current_user), class: "menu-list-heading", method: :get %>
+  </nav>
 
   <div class="menus_list">
     <% if @default_menus.any? %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -29,12 +29,8 @@
     <p class="empty-cart-message">献立が選択されていません。</p>
   <% end %>
 
-
-
-
   <div class="button-set-container">
-    <%= button_to "オリジナル献立リスト", user_custom_menus_path(current_user), class: "button-style bg-custom-menu", method: :get %>
-    <%= button_to "サンプル献立リスト", sample_menus_path, class: "button-style bg-standard-menu", method: :get %>
+    <%= button_to "献立を選ぶ", sample_menus_path, class: "button-style bg-standard-menu", method: :get %>
     <% if @has_menu_items %>
       <%= button_to "買い出しに行く", shopping_lists_path, class: "button-style bg-shopping-list", method: :post, id: "shopping-list", form: { data: { turbo_confirm: "既存の買い出しリストが上書きされます。本当に宜しいですか？" }} %>
     <% else %>


### PR DESCRIPTION
目的：
ホーム画面での献立選択をシンプルにし、ユーザーのナビゲーション体験を向上させるための更新です。

内容：
・「オリジナル献立」ボタンと「サンプル献立」ボタンを「献立を選ぶ」に統合
・献立選択後の各画面において相互に移動できるリンクを追加

<img width="1436" alt="スクリーンショット 2024-01-26 2 31 36" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/3af7c1ee-2a7d-4a4c-9b67-d6463d7a2c8e">
<img width="1439" alt="スクリーンショット 2024-01-26 2 31 44" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/eaa91ca2-c81e-4039-a301-8525b0191c23">
<img width="1440" alt="スクリーンショット 2024-01-26 2 34 09" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/d1037dec-d265-4c98-9aa3-0ff9a285f166">
<img width="224" alt="スクリーンショット 2024-01-26 2 32 10" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/9e2dc6a1-3698-473f-ac94-bcda76fe96ff">
<img width="225" alt="スクリーンショット 2024-01-26 2 32 21" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/7074f64b-88fc-4123-95a4-570c35ee7ee4">
<img width="225" alt="スクリーンショット 2024-01-26 2 34 00" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/8e48a88a-fee1-406b-96ef-97e110f543b4">
