### PR TITLE
スマホ画面用の戻るボタンを画面中央に配置するスタイルに修正

### DIFF
--- a/app/assets/stylesheets/shared/_back_button.scss
+++ b/app/assets/stylesheets/shared/_back_button.scss
@@ -1,12 +1,15 @@
 .scroll-to-top-button {
   display: none;
   position: fixed;
-  left: 15px;
+  left: 0;
+  right: 0;
   bottom: 30px;
   z-index: 20;
   border-radius: 50%;
   width: 70px;
   height: 70px;
+  margin-left: auto;
+  margin-right: auto;
   background-color: rgba(255, 255, 255, 0.8);
   box-shadow: 0 2px 4px rgba(0,0,0,0.5);
   justify-content: center;


### PR DESCRIPTION
目的：
スマホ利用時の操作性を高めるため、戻るボタンをよりアクセスしやすい位置に配置します。

内容：
・スマホ画面における戻るボタンの位置を画面中央に変更
・ボタンの表示をメディアクエリを用いてスマホサイズに最適化

<img width="225" alt="スクリーンショット 2024-01-26 2 32 21" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/3b7ab334-2776-47b3-9a20-be87a9badbd4">