### PR TITLE
献立登録の画像データ保存不具合を修正

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -78,6 +78,13 @@ class MenusController < ApplicationController
       @encoded_image = Base64.strict_encode64(image_data)
     end
 
+    # 編集時に再登録はしなかったが、最初に登録した画像データがある場合は再格納
+    if params[:menu][:image_data_url].present?
+      @image_data_url = params[:menu][:image_data_url]
+      @encoded_image = params[:menu][:encoded_image]
+    end
+
+
     if @menu.valid?
       render_confirm_page
     else

--- a/app/views/menus/_menu_confirm_details.html.erb
+++ b/app/views/menus/_menu_confirm_details.html.erb
@@ -37,6 +37,7 @@
 
     <% if image_data_url.present? %>
       <img src="<%= image_data_url %>" width="300" height="200" alt="uploaded image preview" />
+      <%= f.hidden_field :image_data_url, value: image_data_url %>
       <%= f.hidden_field :encoded_image, value: encoded_image %>
       <%= f.hidden_field :image_content_type, value: image_content_type %>
     <% else %>
@@ -61,15 +62,15 @@
           </div>
         </div>
       <% end %>
+
+      <% menu.ingredients.each_with_index do |ingredient, index| %>
+        <%= f.hidden_field "ingredients[#{index}][material_name]", value: ingredient.material_name %>
+        <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
+        <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
+        <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
+      <% end %>
     <% else %>
       <p class="no-ingredients">食材はありません</p>
-    <% end %>
-
-    <% menu.ingredients.each_with_index do |ingredient, index| %>
-      <%= f.hidden_field "ingredients[#{index}][material_name]", value: ingredient.material_name %>
-      <%= f.hidden_field "ingredients[#{index}][material_id]", value: ingredient.material.id %>
-      <%= f.hidden_field "ingredients[#{index}][quantity]", value: ingredient.quantity %>
-      <%= f.hidden_field "ingredients[#{index}][unit_id]", value: ingredient.unit.id %>
     <% end %>
   </div>
 </div>

--- a/app/views/menus/_review_edit_menu_fields.html.erb
+++ b/app/views/menus/_review_edit_menu_fields.html.erb
@@ -6,11 +6,13 @@
 <%= f.hidden_field :image_content_type, value: menu.image.content_type %>
 <%= f.hidden_field :image_data_url, value: image_data_url %>
 
-<% menu.ingredients.each_with_index do |ingredient, index| %>
-  <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>
-  <%= f.hidden_field "ingredients_attributes[#{index}][material_id]", value: ingredient.material.id %>
-  <%= f.hidden_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity %>
-  <%= f.hidden_field "ingredients_attributes[#{index}][unit_id]", value: ingredient.unit.id %>
+<% if menu.ingredients.present? %>
+  <% menu.ingredients.each_with_index do |ingredient, index| %>
+    <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>
+    <%= f.hidden_field "ingredients_attributes[#{index}][material_id]", value: ingredient.material.id %>
+    <%= f.hidden_field "ingredients_attributes[#{index}][quantity]", value: ingredient.quantity %>
+    <%= f.hidden_field "ingredients_attributes[#{index}][unit_id]", value: ingredient.unit.id %>
+  <% end %>
 <% end %>
 
 <%= f.submit "戻る", class: "edit-button" %>


### PR DESCRIPTION
目的：
ユーザーが献立情報の編集から確認へスムーズに進むため、画像データの継続的な保存できるよう修正することが目的です。

内容：
・献立登録時の「編集」と「次へ」の間の画像データ損失のバグを修正
・画像データがセッション間で正しく保持されるようロジックを改善