### PR TITLE
ユーザー名変更アクションの実装、ユーザー情報更新機能に関する表現の統一

### DIFF
--- a/app/controllers/custom_registrations_controller.rb
+++ b/app/controllers/custom_registrations_controller.rb
@@ -25,14 +25,32 @@ class CustomRegistrationsController < ApplicationController
   end
 
 
-  def edit_user
+  # ユーザー名の変更画面
+  def edit_user_name
   end
 
 
-  def edit_password
+  # ユーザー名の変更アクション
+  def user_name_update
+    if params[:user][:name].blank?
+      set_flash_and_redirect(:error, "未入力があります。", edit_user_name_custom_registration_path)
+      return
+    end
+
+    if current_user.update(registration_params)
+      set_flash_and_redirect(:notice, "ユーザー名を更新しました。", edit_user_name_custom_registration_path)
+    else
+      set_flash_and_redirect(:error, set_validation_error(current_user), edit_user_name_custom_registration_path)
+    end
   end
 
 
+  # メールアドレスの変更画面
+  def edit_email
+  end
+
+
+  # メールアドレスの変更アクション
   def email_update
     if params[:user][:email].blank?
       set_flash_and_redirect(:error, "未入力があります。", edit_email_custom_registration_path)
@@ -45,7 +63,6 @@ class CustomRegistrationsController < ApplicationController
       return
     end
 
-    # ユーザー情報の更新
     # 新しいメールアドレスに確認メールを送信
     if current_user.update(registration_params)
       set_flash_and_redirect(:notice, "メールアドレス更新の確認メールを送信しました。", edit_email_custom_registration_path)
@@ -55,6 +72,12 @@ class CustomRegistrationsController < ApplicationController
   end
 
 
+  # パスワードの変更画面
+  def edit_password
+  end
+
+
+  # パスワードの変更アクション
   def password_info_update
     if password_info_missing?
       set_flash_and_redirect(:error, "未入力があります。", edit_password_user_custom_registration_path)
@@ -92,6 +115,6 @@ class CustomRegistrationsController < ApplicationController
   end
 
   def registration_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, :current_password, :email_change, :password_change)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :current_password, :user_info_change, :email_change, :password_change)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,14 +2,17 @@ class UsersController < ApplicationController
   include Devise::Controllers::Helpers
   before_action :authenticate_user!
 
+  # ホーム画面のアクション
   def index
     cart = current_user.cart
     @cart_items = cart.cart_items.includes(:menu) if cart
   end
 
+  # マイページ画面のアクション
   def my_page
   end
 
+  # ユーザー情報画面のアクション
   def user_info
     @user = User.find(params[:id])
   end

--- a/app/views/custom_registrations/edit_email.html.erb
+++ b/app/views/custom_registrations/edit_email.html.erb
@@ -1,7 +1,7 @@
 <div class="edit-registration-container" id="email-validation-area">
 
   <div class="registration-title">
-    <h1>メールアドレス更新</h1>
+    <h1>メールアドレス変更</h1>
   </div>
 
   <div class="registration-instructions">
@@ -18,7 +18,7 @@
       </div>
 
       <div class="registration-actions">
-        <%= f.submit "更新", id: "update-user-submit" %>
+        <%= f.submit "確認メールを送信", id: "update-user-submit" %>
       </div>
 
     <% end %>

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -33,7 +33,7 @@
       </div>
 
       <div class="registration-actions">
-        <%= f.submit "更新", id: "update-password-submit" %>
+        <%= f.submit "変更", id: "update-password-submit" %>
       </div>
     <% end %>
     <div class="registration-back-button">

--- a/app/views/custom_registrations/edit_user_name.html.erb
+++ b/app/views/custom_registrations/edit_user_name.html.erb
@@ -1,0 +1,29 @@
+<div class="edit-registration-container">
+
+  <div class="registration-title">
+    <h1>ユーザー名変更</h1>
+  </div>
+
+  <div class="registration-instructions">
+    <p>ユーザー名は2〜15文字、英数字で設定をしてください。</p>
+  </div>
+
+  <div class="registration-input">
+    <%= form_with model: current_user, url: user_name_update_custom_registration_path, local: true, method: :patch do |f| %>
+      <%= f.hidden_field :user_info_change, value: true %>
+
+      <div class="registration-field">
+        <div class="error-message"></div>
+        <%= f.text_field :name, name: 'user[name]', autocomplete: "name", placeholder: "ユーザー名" %>
+      </div>
+
+      <div class="registration-actions">
+        <%= f.submit "変更" %>
+      </div>
+
+    <% end %>
+    <div class="registration-back-button">
+    <%= button_to "戻る", user_info_path(current_user), class: "back-button", method: :get %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/user_info.html.erb
+++ b/app/views/users/user_info.html.erb
@@ -10,7 +10,7 @@
       <p class="label">ユーザー名:</p>
       <div class="detail-and-edit">
         <p class="detail"><%= @user.name %></p>
-        <%= link_to "変更", '#', class: "edit-link" %>
+        <%= link_to "変更", edit_user_name_custom_registration_path, class: "edit-link" %>
       </div>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,18 +42,22 @@ Rails.application.routes.draw do
     get 'users/session', to: 'custom_sessions#new', as: :new_user_custom_session
     post 'users/session', to: 'custom_sessions#create', as: :user_custom_session
     get 'users/sessions', to: 'custom_sessions#destroy', as: :destroy_user_custom_session
-    get 'registrations/edit_email', to: 'custom_registrations#edit_email', as: :edit_email_custom_registration
-    get 'registrations/edit_password', to: 'custom_registrations#edit_password', as: :edit_password_user_custom_registration
 
+    # パスワードを忘れた場合の処理に関するルーチング
     get 'password/request_reset', to: 'custom_passwords#request_reset', as: :request_reset_password
     post 'password/send_reset_instructions', to: 'custom_passwords#send_reset_instructions', as: :send_reset_instructions
     get 'password/verify_reset_token', to: 'custom_passwords#verify_reset_token', as: :verify_reset_token
     get 'password/edit', to: 'custom_passwords#edit_password', as: :edit_password
     patch 'password/update', to: 'custom_passwords#update_password', as: :update_password
 
-    # ユーザー情報更新用のルーティング
+    # ユーザー名更新用のルーティング
+    get 'registrations/edit_user_name', to: 'custom_registrations#edit_user_name', as: :edit_user_name_custom_registration
+    patch 'registrations/user_name_update', to: 'custom_registrations#user_name_update', as: :user_name_update_custom_registration
+    # メールアドレス更新用のルーティング
+    get 'registrations/edit_email', to: 'custom_registrations#edit_email', as: :edit_email_custom_registration
     patch 'registrations/email_update', to: 'custom_registrations#email_update', as: :email_update_custom_registration
-    # パスワード情報更新用のルーティング
+    # パスワード更新用のルーティング
+    get 'registrations/edit_password', to: 'custom_registrations#edit_password', as: :edit_password_user_custom_registration
     patch 'registrations/update_password_info', to: 'custom_registrations#password_info_update', as: :password_info_update_custom_registration
 
     resources :users do


### PR DESCRIPTION
目的：
ユーザーが自身の情報を容易に管理・更新できるよう、マイページ内のユーザー情報更新機能を強化します。

内容：
・ユーザー名変更機能のための新しいページとupdate アクションの実装
・ユーザー情報更新画面におけるボタン表現を「変更」に統一
・メールアドレス変更時のボタンを「メールを送信」に変更

ユーザー名変更画面：
<img width="1440" alt="スクリーンショット 2024-01-27 14 04 47" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/381a6bf3-dd77-4030-aa08-28d459e2fa45">
<img width="1440" alt="スクリーンショット 2024-01-27 14 05 03" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/a872c9ac-3244-49c7-ad7a-ea8364c4548a">
<img width="1440" alt="スクリーンショット 2024-01-27 14 05 11" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/79330a5f-59d3-418a-8eb3-44d1de052614">
<img width="1440" alt="スクリーンショット 2024-01-27 14 05 20" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/d013103c-849e-4847-b379-5d82f229e01b">

メールアドレス変更時の画面にある表現を「変更」に統一、ボタンを「メールを送信」に変更：
<img width="1440" alt="スクリーンショット 2024-01-27 14 07 38" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/ea761c3c-5ee5-459c-b2be-b685e93a7517">

パスワード更新画面にある表現を「変更」に統一：
<img width="1440" alt="スクリーンショット 2024-01-27 14 07 47" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/69f627eb-2d64-4571-aa5a-9eb1a7af2935">