### PR TITLE
メールアドレス変更説明の追加と説明文の視認性向上

### DIFF
--- a/app/assets/stylesheets/edit_custom_registration.scss
+++ b/app/assets/stylesheets/edit_custom_registration.scss
@@ -14,6 +14,7 @@
 
   .registration-instructions{
     @include form-instructions;
+    margin-bottom: 20px;
   }
 
   .registration-input{

--- a/app/assets/stylesheets/shared/_styles.scss
+++ b/app/assets/stylesheets/shared/_styles.scss
@@ -32,7 +32,6 @@
   position: relative;
   margin-top: -40px;
   margin-bottom: 10px;
-  opacity: 0.4;
   @media screen and (max-width: 600px) {
     font-size: 10px;
   }

--- a/app/views/custom_registrations/edit_email.html.erb
+++ b/app/views/custom_registrations/edit_email.html.erb
@@ -5,7 +5,11 @@
   </div>
 
   <div class="registration-instructions">
-    <p>登録内容は管理者および本人以外には公開されません。</p>
+    <p>変更手続きでは、入力されたメールアドレスへ<br>
+    確認メールをお送りいたします。</p>
+
+    <p>セキュリティ保護のため、メールに記載された<br>
+    リンクは24時間後に無効となります。</p>
   </div>
 
   <div class="registration-input">

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -6,7 +6,8 @@
 
   <div class="registration-instructions">
     <p>更新後、新しいパスワードで再ログインが必要です。<br>
-    ※パスワード: 8文字以上、大小英字、数字、記号を含む</p>
+    ※パスワードの変更8文字以上、大小英字、数字、記号を<br>
+    含んでください。</p>
   </div>
 
   <div class="registration-input">


### PR DESCRIPTION
目的：
ユーザーがメールアドレス変更プロセスを明確に理解しやすくするため、詳細な説明を追加し、説明文の視認性を向上させます。

内容：
・メールアドレス変更画面に、メール検証プロセスの詳細な説明を追加
・説明文に適用されていた opacity スタイルを削除し、テキストの視認性を向上
・メールアドレス更新の重要性を強調し、ユーザーが手順を容易に理解できるよう調整

メールアドレス変更画面：
<img width="1440" alt="スクリーンショット 2024-01-27 14 25 49" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/6bac2719-9593-40b9-ae70-6abe86af8ca6">

opacity スタイルを削除による影響のあるページ：
<img width="1440" alt="スクリーンショット 2024-01-27 14 25 56" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/3e1154bb-827c-4bc8-9923-8919eb33ca4b">
<img width="1440" alt="スクリーンショット 2024-01-27 14 26 03" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/c2469298-dba3-4f96-aa17-02705a43d537">
<img width="1440" alt="スクリーンショット 2024-01-27 14 26 15" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/79cdaf60-7929-49fe-9d69-b545d2616e57">
<img width="1440" alt="スクリーンショット 2024-01-27 14 26 22" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/01a56dbc-284d-427f-8d4d-2a08a0f3e41e">