### PR TITLE
ログアウト時の確認ダイヤログを設定し、不要なjs設定を削除

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
-import "nav_menu"
 import "checkbox_button_control"
 import "menu_button_style_update"
 import "email_validation"

--- a/app/views/users/my_page.html.erb
+++ b/app/views/users/my_page.html.erb
@@ -11,11 +11,7 @@
     </div>
 
     <div class="my-page-button">
-      <%= button_to "オリジナル献立一覧", '#', class: "my-page-button", method: :get %>
-    </div>
-
-    <div class="my-page-button">
-      <%= button_to "ログアウト", destroy_user_custom_session_path, class: "log-out-button", method: :get %>
+      <%= button_to "ログアウト", destroy_user_custom_session_path, class: "log-out-button", method: :get, form: { data: { turbo_confirm: "ログアウトしてもよろしいですか？" }} %>
     </div>
 
     <div class="my-page-back-button">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,7 +5,6 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
-pin "nav_menu", to: "nav_menu.js", preload: true
 pin "checkbox_button_control", to: "checkbox_button_control.js", preload: true
 pin "menu_button_style_update", to: "menu_button_style_update.js", preload: true
 pin "email_validation", to: "email_validation.js", preload: true


### PR DESCRIPTION
目的：
誤ってログアウトするリスクを減らし、システムの安定性を保つことです。

内容：
・マイページの「ログアウト」ボタンに確認ダイアログを追加
・不要なJavaScript設定を削除

<img width="707" alt="スクリーンショット 2024-01-28 22 20 30" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/c8caeab9-7b5f-4e21-9d42-fa1a8a188704">