### PR TITLE
menuの削除機能と確認ダイヤログの実装

### DIFF
--- a/app/assets/stylesheets/menu/menu_show.scss
+++ b/app/assets/stylesheets/menu/menu_show.scss
@@ -127,22 +127,34 @@
     }
 
     .edit-button,
-    .back-button {
+    .back-button,
+    .delete_button {
       @include button;
       width: 49%;
     }
 
+    .edit-button,
+    .delete_button{
+      margin-top: 20px;
+      margin-bottom: 20px;
+    }
+
     .edit-button{
       background-color: #777;
-      margin-bottom: 10px;
-
       &:hover {
         background-color: lighten(#7d7d7d, 10%);
       }
     }
 
+    .delete_button{
+      background-color: #ff3636;
+      &:hover {
+        background-color: lighten(#faadad, 10%);
+      }
+    }
+
     .back-button {
-      margin-top: 10px;
+      margin-top: 20px;
     }
   }
 }

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -237,6 +237,22 @@ class MenusController < ApplicationController
     redirect_to user_menu_path(user_id: current_user.id, id: params[:menu][:menu_id])
   end
 
+
+  def destroy
+    # menu_idからデータを取得
+    menu = Menu.find(params[:menu_id])
+    # menu_idに該当するshopping_list_menusデータがあるかチェック
+    if menu.shopping_list_menus.exists?
+      flash[:error] = "この献立は現在選択されています。"
+      redirect_to user_menu_path(menu_id: menu.id)
+    else
+      # menuデータを削除
+      menu.destroy
+      flash[:notice] = "献立を削除しました。"
+      redirect_to user_custom_menus_path
+    end
+  end
+
   private
 
   def menu_params

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,5 +1,5 @@
 class Menu < ApplicationRecord
-  has_many :menu_users, dependent: :destroy
+  has_many :user_menu, dependent: :destroy
   has_many :users, through: :menu_users
   has_one_attached :image
   has_many :menu_ingredients, dependent: :destroy

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -23,6 +23,7 @@
   <div class="menu-button-container">
     <% if UserMenu.exists?(menu_id: @menu.id, user_id: current_user.id) %>
       <%= button_to '編集', edit_user_menu_path(@menu), method: :get, class: 'edit-button', id: 'edit_button' %>
+      <%= button_to '削除', user_menu_path(current_user, menu_id: @menu.id), method: :delete, class: 'delete_button', id: 'delete_button', form: { data: { turbo_confirm: "本当に削除してよろしいでしょうか？" }}  %>
       <%= button_to '戻る', user_custom_menus_path(current_user), method: :get, class: 'back-button', id: 'back_button' %>
     <% else %>
       <%= button_to '戻る', sample_menus_path(current_user), method: :get, class: 'back-button', id: 'back_button' %>


### PR DESCRIPTION
目的：
menuの削除機能の実装により、作成した献立を削除できるようにすることが目的です。

内容：
・献立の詳細画面に削除ボタンを設定
・menuの削除機能を実装
・削除時の確認ダイヤログ表示機能を追加

<img width="1437" alt="スクリーンショット 2024-01-29 1 22 42" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/247c7359-d5b3-4eaa-bd5c-c4f94ba0eff4">
<img width="1435" alt="スクリーンショット 2024-01-29 1 22 47" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/6bfe5b85-a8ad-45ba-93bd-d2daf9959540">