### PR TITLE
“選択中の献立の編集・削除防止をbefore_actionで設定“

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -3,6 +3,7 @@ class MenusController < ApplicationController
   include ServingSizeHandler
   include IngredientScaler
   before_action :set_and_sort_materials_by_category, only: [:new, :edit]
+  before_action :check_menu_selection, only: [:edit, :destroy]
 
   def custom_menus
     # 現在ログインしているユーザーのIDに関連付けられたすべてのメニューIDを取得
@@ -170,7 +171,7 @@ class MenusController < ApplicationController
       render 'edit', status: :unprocessable_entity
     else
       # 通常の `edit` リクエスト処理
-      @menu = Menu.find(params[:id])
+      @menu = Menu.find(params[:menu_id])
     end
 
     # MenuIngredient モデルを使用して ingredient_id のリストを取得
@@ -335,4 +336,10 @@ class MenusController < ApplicationController
     end
   end
 
+  def check_menu_selection
+    if current_user.cart.cart_items.exists?(menu_id: params[:menu_id])
+      flash[:error] = "この献立は現在選択されているため、編集（削除）はできません。"
+      redirect_to user_menu_path(menu_id: params[:menu_id])
+    end
+  end
 end

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -22,7 +22,7 @@
 
   <div class="menu-button-container">
     <% if UserMenu.exists?(menu_id: @menu.id, user_id: current_user.id) %>
-      <%= button_to '編集', edit_user_menu_path(@menu), method: :get, class: 'edit-button', id: 'edit_button' %>
+      <%= button_to '編集', edit_user_menu_path, params: { menu_id: @menu.id }, method: :get, class: 'edit-button', id: 'edit_button' %>
       <%= button_to '削除', user_menu_path(current_user, menu_id: @menu.id), method: :delete, class: 'delete_button', id: 'delete_button', form: { data: { turbo_confirm: "本当に削除してよろしいでしょうか？" }}  %>
       <%= button_to '戻る', user_custom_menus_path(current_user), method: :get, class: 'back-button', id: 'back_button' %>
     <% else %>


### PR DESCRIPTION
目的：
買い物リストの整合性を保つため、選択中の献立の編集や削除を防ぎます。

内容：
・選択中の献立が誤って編集・削除されるのを防止
・MenusControllerにbefore_actionコールバックを設定
・既にカートに入っている献立に対する操作を制限

<img width="1439" alt="スクリーンショット 2024-02-02 3 27 38" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/3821c4af-2867-48a4-abcd-aa28e03a252f">
