### PR TITLE
current_userのカート取得をhelper_methodで簡略化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include Devise::Controllers::Helpers
   before_action :authenticate_user!
   before_action :load_settings
+  helper_method :current_user_cart
 
   private
 
@@ -19,5 +20,9 @@ class ApplicationController < ActionController::Base
   def handle_general_error
     flash[:error] = "登録中に予期せぬエラーが発生しました。"
     redirect_to root_path
+  end
+
+  def current_user_cart
+    current_user.cart
   end
 end

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -4,7 +4,7 @@ class CartItemsController < ApplicationController
 
   def create
     # 現在のユーザーのカートを取得または新規作成
-    cart = current_user.cart || current_user.create_cart
+    cart = current_user_cart || current_user.create_cart
 
     # 各モデルからのアイテム数の総計を取得
     total_items_count = total_items_count(cart)
@@ -38,11 +38,10 @@ class CartItemsController < ApplicationController
     cart_item = CartItem.find(params[:id])
     cart_item.destroy
 
-    cart = current_user.cart
-    shopping_list = cart.shopping_list
+    shopping_list = current_user_cart.shopping_list
 
     # カート内のアイテムが空になったかチェック
-    if cart.cart_items.empty?
+    if current_user_cart.cart_items.empty?
       # ショッピングリスト内のアイテムとメニューを全て削除
       shopping_list.shopping_list_items.delete_all
       shopping_list.shopping_list_menus.delete_all

--- a/app/controllers/completed_menus_controller.rb
+++ b/app/controllers/completed_menus_controller.rb
@@ -14,7 +14,7 @@ class CompletedMenusController < ApplicationController
 
   def create
     # 現在のユーザーのShoppingListMenuからデータを取得
-    shopping_list = current_user.cart.shopping_list
+    shopping_list = current_user_cart.shopping_list
 
     # 現在登録されている買い物リストデータ
     shopping_list_menus = ShoppingListMenu.where(shopping_list_id: shopping_list.id)

--- a/app/controllers/concerns/shopping_list_updater.rb
+++ b/app/controllers/concerns/shopping_list_updater.rb
@@ -296,12 +296,10 @@ module ShoppingListUpdater
   def update_shopping_list
     begin
       ActiveRecord::Base.transaction do
-        # ユーザーのカートを取得
-        cart = current_user.cart
         # カートの中にあるmenu_idとその個数のデータを取得
-        cart_items = cart.cart_items
+        cart_items = current_user_cart.cart_items
         # ショッピングリストを取得または作成
-        shopping_list = cart.shopping_list || cart.create_shopping_list
+        shopping_list = current_user_cart.shopping_list || current_user_cart.create_shopping_list
         # カート内のアイテムから献立IDと数量のハッシュを生成するメソッド
         menu_item_counts = get_menu_item_counts(cart_items)
 

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -337,7 +337,7 @@ class MenusController < ApplicationController
   end
 
   def check_menu_selection
-    if current_user.cart.cart_items.exists?(menu_id: params[:menu_id])
+    if current_user_cart.cart_items.exists?(menu_id: params[:menu_id])
       flash[:error] = "この献立は現在選択されているため、編集（削除）はできません。"
       redirect_to user_menu_path(menu_id: params[:menu_id])
     end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -3,7 +3,7 @@ class ShoppingListsController < ApplicationController
   include ShoppingListUpdater
 
   def index
-    shopping_list = current_user.cart.shopping_list
+    shopping_list = current_user_cart.shopping_list
 
     # ショッピングリストメニューを取得
     shopping_list_menus = shopping_list.shopping_list_menus.includes(menu: [image_attachment: :blob])
@@ -40,12 +40,10 @@ class ShoppingListsController < ApplicationController
   def create
     begin
       ActiveRecord::Base.transaction do
-        # ユーザーのカートを取得
-        cart = current_user.cart
         # カートの中にあるmenu_idとその個数のデータを取得
-        cart_items = cart.cart_items
+        cart_items = current_user_cart.cart_items
         # ショッピングリストを取得または作成
-        shopping_list = cart.shopping_list || cart.create_shopping_list
+        shopping_list = current_user_cart.shopping_list || current_user_cart.create_shopping_list
 
         # チェック済みの食材リストデータを直接データベースから取得
         checked_items = ShoppingListItem.where(shopping_list_id: shopping_list.id, is_checked: true)
@@ -110,10 +108,8 @@ class ShoppingListsController < ApplicationController
     # 確認ダイアログが必要かどうかを決定するために使用される。
     requires_attention = false
 
-    # ユーザーのカートを取得
-    cart = current_user.cart
     # ショッピングリストを取得または作成
-    shopping_list = cart.shopping_list || cart.create_shopping_list
+    shopping_list = current_user_cart.shopping_list || current_user_cart.create_shopping_list
     # チェック済みの食材リストデータをデータベースから取得
     checked_items = ShoppingListItem.where(shopping_list_id: shopping_list.id, is_checked: true)
 
@@ -121,7 +117,7 @@ class ShoppingListsController < ApplicationController
     # 例：✔︎鶏肉 200g, ✔︎鶏肉 100g → ✔︎鶏肉 300g
     aggregate_and_update_checked_items(checked_items)
     # カートの中にある献立データを取得
-    cart_items = cart.cart_items
+    cart_items = current_user_cart.cart_items
 
     # cart_itemsから指定されたmenu_idを持つアイテムを更新または除外
     # データを減らし、実際のデータと比較することで食材リストのチェックされている値（例：✔︎鶏肉 200g）に影響があるかチェック

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,8 +4,7 @@ class UsersController < ApplicationController
 
   # ホーム画面のアクション
   def index
-    cart = current_user.cart
-    @cart_items = cart.cart_items.includes(:menu).order(:added_at) if cart
+    @cart_items = current_user_cart.cart_items.includes(:menu).order(:added_at) if current_user_cart
   end
 
   # マイページ画面のアクション


### PR DESCRIPTION
目的：
コードの再利用性と可読性を高めることです。

内容：
・current_user_cartをhelper_methodとして設定
・コントローラーとビューでのcurrent_user.cartの呼び出しを簡略化