### PR TITLE
単位「少々」選択時の食材数量自動削除機能を追加して誤った入力が反映されてしまう不具合修正

### DIFF
--- a/app/javascript/ingredient_dropdown.js
+++ b/app/javascript/ingredient_dropdown.js
@@ -194,6 +194,7 @@ function handleIngredientUnitChange(clickedElement) {
       inputElement.style.pointerEvents = "none";
       inputElement.setAttribute("readonly", true);
       inputElement.setAttribute("tabindex", "-1");
+      inputElement.value = "";
       inputElement.placeholder = "";
     } else {
       inputElement.style.backgroundColor = "";


### PR DESCRIPTION
目的：
単位「少々」選択時に以前の入力内容が設定される不具合を防ぎ、食材登録の正確性を確保することです。

内容：
・単位「少々」を選択した際に、自動で既存の食材数量を削除する機能を追加
・誤った数量入力が反映される問題を解決