### PR TITLE
献立編集時の単位自動設定による不具合修正、単位設定時の順番を統一されるよう改善

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -100,7 +100,10 @@ class MenusController < ApplicationController
     units = material.material_units.map do |material_unit|
       { id: material_unit.unit_id, name: material_unit.unit.unit_name }
     end
-    render json: units
+
+    # unit_id で昇順にソート
+    sorted_units = units.sort_by { |unit| unit[:id] }
+    render json: sorted_units
   end
 
 


### PR DESCRIPTION
目的：
献立編集時にユーザーが指定した単位が正確に反映され、混乱を避けることを目的とします。

内容：
・献立編集画面における単位の自動設定不具合を修正し、ユーザー選択を正確に反映
・単位のドロップダウンリストをIDの昇順で表示し、選択の一貫性を向上

新規入力画面：
<img width="887" alt="スクリーンショット 2024-02-05 3 27 32" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/141e57c8-c9a9-4457-ad50-334465bf4741">

編集画面：
<img width="890" alt="スクリーンショット 2024-02-05 3 27 44" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/3e256390-79be-4595-83de-3f6d0c8be4f4">
