### PR TITLE
“フォーム要素の自動フォーカスを無効にする設定を追加“

### DIFF
--- a/app/views/custom_passwords/edit_password.html.erb
+++ b/app/views/custom_passwords/edit_password.html.erb
@@ -16,12 +16,12 @@
 
       <div class="password-update-field">
         <div class="error-message"></div>
-        <%= f.password_field :password, name: 'user[password]', autocomplete: "off", placeholder: "新しいパスワードを入力" %>
+        <%= f.password_field :password, autofocus: false, name: 'user[password]', autocomplete: "off", placeholder: "新しいパスワードを入力" %>
       </div>
 
       <div class="password-update-field">
         <div class="error-message"></div>
-        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "off", placeholder: "もう一度新しいパスワードを入力" %>
+        <%= f.password_field :password_confirmation, autofocus: false, name: 'user[password_confirmation]', autocomplete: "off", placeholder: "もう一度新しいパスワードを入力" %>
       </div>
 
       <div class="password-update-actions">

--- a/app/views/custom_passwords/request_reset.html.erb
+++ b/app/views/custom_passwords/request_reset.html.erb
@@ -12,7 +12,7 @@
     <%= form_with url: send_reset_instructions_path, local: true, method: :post do |f| %>
       <div class="password-reset-request-field">
         <div class="error-message"></div>
-        <%= f.email_field :email, name: 'user[email]', autocomplete: "email", placeholder: "メールアドレス" %>
+        <%= f.email_field :email, autofocus: false, name: 'user[email]', autocomplete: "email", placeholder: "メールアドレス" %>
       </div>
 
       <div class="password-reset-request-actions">

--- a/app/views/custom_registrations/edit_email.html.erb
+++ b/app/views/custom_registrations/edit_email.html.erb
@@ -18,7 +18,7 @@
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.email_field :email, autocomplete: "email", placeholder: "メールアドレス" %>
+        <%= f.email_field :email, autofocus: false, autocomplete: "email", placeholder: "メールアドレス" %>
       </div>
 
       <div class="registration-actions">

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -16,17 +16,17 @@
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.text_field :current_password, name: 'user[current_password]', autocomplete: "off", placeholder: "現在のパスワードを入力" %>
+        <%= f.text_field :current_password, autofocus: false, name: 'user[current_password]', autocomplete: "off", placeholder: "現在のパスワードを入力" %>
       </div>
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.password_field :password, name: 'user[password]', autocomplete: "off", placeholder: "新しいパスワードを入力" %>
+        <%= f.password_field :password, autofocus: false, name: 'user[password]', autocomplete: "off", placeholder: "新しいパスワードを入力" %>
       </div>
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "off", placeholder: "もう一度新しいパスワードを入力" %>
+        <%= f.password_field :password_confirmation, autofocus: false, name: 'user[password_confirmation]', autocomplete: "off", placeholder: "もう一度新しいパスワードを入力" %>
       </div>
 
       <div class="registration-link">

--- a/app/views/custom_registrations/edit_user_name.html.erb
+++ b/app/views/custom_registrations/edit_user_name.html.erb
@@ -14,7 +14,7 @@
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.text_field :name, name: 'user[name]', autocomplete: "name", placeholder: "ユーザー名" %>
+        <%= f.text_field :name, autofocus: false, name: 'user[name]', autocomplete: "name", placeholder: "ユーザー名" %>
       </div>
 
       <div class="registration-actions">

--- a/app/views/custom_registrations/new.html.erb
+++ b/app/views/custom_registrations/new.html.erb
@@ -14,22 +14,22 @@
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.text_field :name, name: 'user[name]', autocomplete: "name", placeholder: "ユーザー名（2〜15文字、英数字）" %>
+        <%= f.text_field :name, autofocus: false, name: 'user[name]', autocomplete: "name", placeholder: "ユーザー名（2〜15文字、英数字）" %>
       </div>
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.email_field :email, name: 'user[email]', autocomplete: "email", placeholder: "メールアドレス" %>
+        <%= f.email_field :email, autofocus: false, name: 'user[email]', autocomplete: "email", placeholder: "メールアドレス" %>
       </div>
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.password_field :password, name: 'user[password]', autocomplete: "password", placeholder: "パスワード（8~128文字、英数記号含む）" %>
+        <%= f.password_field :password, autofocus: false, name: 'user[password]', autocomplete: "password", placeholder: "パスワード（8~128文字、英数記号含む）" %>
       </div>
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.password_field :password_confirmation, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "確認用パスワード" %>
+        <%= f.password_field :password_confirmation, autofocus: false, name: 'user[password_confirmation]', autocomplete: "password_confirmation", placeholder: "確認用パスワード" %>
       </div>
 
       <div class="registration-actions">

--- a/app/views/custom_sessions/new.html.erb
+++ b/app/views/custom_sessions/new.html.erb
@@ -12,11 +12,11 @@
     <%= form_with url: user_custom_session_path, local: true, data: { turbo: false } do |f| %>
       <div class="session-field">
         <div class="error-message"></div>
-        <%= f.email_field :email, autocomplete: "email", name: 'user[email]', placeholder: "メールアドレス" %>
+        <%= f.email_field :email, autofocus: false, autocomplete: "email", name: 'user[email]', placeholder: "メールアドレス" %>
       </div>
       <div class="session-field">
         <div class="error-message"></div>
-        <%= f.password_field :password, autocomplete: "new-password", name: 'user[password]', placeholder: "パスワード（8~128文字、英数記号含む）" %>
+        <%= f.password_field :password, autofocus: false, autocomplete: "new-password", name: 'user[password]', placeholder: "パスワード（8~128文字、英数記号含む）" %>
       </div>
       <div class="session-actions">
         <%= f.submit "ログイン" %>

--- a/app/views/menus/_form_fields.html.erb
+++ b/app/views/menus/_form_fields.html.erb
@@ -1,18 +1,18 @@
 <div id="menu-error_name" class="menu-error"></div>
 <div class="name-form-field">
-  <%= f.text_field :menu_name, id: "menu_name", autofocus: true, autocomplete: "menu_name", placeholder: "献立名(最大20字)", maxlength: 20 %>
+  <%= f.text_field :menu_name, autofocus: false, id: "menu_name", autocomplete: "menu_name", placeholder: "献立名(最大20字)", maxlength: 20 %>
 </div>
 
 <div id="menu-error-menu-contents" class="menu-error"></div>
 <div class="menu-contents-field">
-  <%= f.text_field :menu_contents, id: "menu_contents", autofocus: true, autocomplete: "menu_contents", placeholder: "献立内容(最大20字)", maxlength: 20 %>
+  <%= f.text_field :menu_contents, autofocus: false, id: "menu_contents", autocomplete: "menu_contents", placeholder: "献立内容(最大20字)", maxlength: 20 %>
 </div>
 
 <div id="menu-error-contents" class="menu-error"></div>
 <div class="content-field">
-  <%= f.text_area :contents, id: "contents", autofocus: true, autocomplete: "contents", placeholder: "作り方(最大1500字)", maxlength: 1500 %>
+  <%= f.text_area :contents, autofocus: false, id: "contents", autocomplete: "contents", placeholder: "作り方(最大1500字)", maxlength: 1500 %>
 </div>
 
 <div class="image-field">
-  <%= f.file_field :image, autofocus: true, autocomplete: "image", placeholder: "献立の写真", id: "menu_image" %>
+  <%= f.file_field :image, autofocus: false, autocomplete: "image", placeholder: "献立の写真", id: "menu_image" %>
 </div>


### PR DESCRIPTION
目的：
モバイル端末における入力フォームの挙動改善を目指し、フォーム要素の自動フォーカスを無効にする設定を行いました。本番環境でのテストを通じて、モバイルブラウザでの利便性を向上させることが狙いです。

内容：
・入力フォームのautofocus属性をfalseに設定
・フォームフィールドへの自動フォーカスを防ぐための変更を実施
・本番環境にて動作検証を行うための準備完了