### PR TITLE
食材重複時の単位変換不具合を改善

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -85,7 +85,6 @@ class MenusController < ApplicationController
       @encoded_image = params[:menu][:encoded_image]
     end
 
-
     if @menu.valid?
       render_confirm_page
     else

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,7 @@ limits:
   default_max_serving_size: 35
   min_items_to_process: 1
   min_items_to_decrement: 1
+  unique_unit_id_threshold: 1
 
 confirmation:
   token_validity_hours: 24


### PR DESCRIPTION
目的：
買い物リスト生成時の食材重複バグを修正し、正確な単位で食材を集約することでリストの精度を向上させるという目的です。

内容：
・重複する食材の単位が自動的にデフォルト単位に変換される問題を修正
・同じ単位の食材が正しく合算されるようロジックを改善
・設定ファイルに新たな設定値を追加し、コード内のマジックナンバーを削減
・aggregate_quantitiesメソッドから正しい単位IDを返すように変更

<img width="892" alt="スクリーンショット 2024-02-05 23 14 29" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/43a5ffed-b049-45cf-a580-64d6e0b45d0f">
