### PR TITLE
買い物リストのチェックボックスで要素クリックでもチェック可能に修正

### DIFF
--- a/app/assets/stylesheets/shopping_list.scss
+++ b/app/assets/stylesheets/shopping_list.scss
@@ -133,6 +133,7 @@
         width: 100%;
         margin: auto;
         border-bottom: 2px solid hsla(0, 0%, 0%, 0.3);
+        cursor: pointer;
 
         .custom-checkbox-label {
           display: flex;

--- a/app/javascript/shopping_list_checkbox_handlers.js
+++ b/app/javascript/shopping_list_checkbox_handlers.js
@@ -1,5 +1,38 @@
+setupCheckboxEventListeners();
+setupIngredientItemClickEvents();
 
-setupCheckboxEventListeners()
+function setupCheckboxEventListeners() {
+  // すべての '.custom-checkbox' 要素を選択し、それぞれにリスナーを追加
+  document.querySelectorAll('.custom-checkbox').forEach(function(checkbox) {
+    checkbox.addEventListener('change', handleCheckboxChange);
+  });
+}
+
+function setupIngredientItemClickEvents() {
+  // すべての '.ingredient-item' 要素を選択し、それぞれにリスナーを追加
+  document.querySelectorAll('.ingredient-item').forEach(function(item) {
+    item.addEventListener('click', handleIngredientItemClick);
+  });
+}
+
+// ingredient-item がクリックされたときの処理
+function handleIngredientItemClick(e) {
+  // クリックされた要素から 'custom-checkbox' クラスを持つ要素を検索
+  let checkbox = e.currentTarget.querySelector('.custom-checkbox');
+  // チェックボックスの状態をトグル（切り替え）
+  checkbox.checked = !checkbox.checked;
+
+  // チェックボックスの変更イベントを手動で発火させる
+  triggerCheckboxChangeEvent(checkbox);
+}
+
+// チェックボックスの状態を変更するためのメソッド
+function triggerCheckboxChangeEvent(checkbox) {
+  // 'change' イベントを作成
+  const event = new Event('change');
+  // 作成したイベントを発生させる
+  checkbox.dispatchEvent(event);
+}
 
 // チェックボックスのイベントを設定する関数
 function setupCheckboxEventListeners() {


### PR DESCRIPTION
目的:
要素をクリックしてもチェックボックスをトグルできるように改善し、UXを向上させることが目的です。

内容:
クリックイベントを要素全体に適用し、要素をクリックした際にチェックボックスの状態を切り替える機能を追加しました。
チェックボックスのイベントリスナーを要素クリックに関連付け、チェックボックスの変更と要素クリックの同時実行を可能にしました。

要素をクリックした際のチェックボックスの状態:
<img width="874" alt="スクリーンショット 2024-02-06 1 20 08" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/035c80a3-5423-428a-95e0-ee4bfe58517a">
