### PR TITLE
“入力フォームのフォントサイズを16pxに変更“

### DIFF
--- a/app/assets/stylesheets/custom_registration.scss
+++ b/app/assets/stylesheets/custom_registration.scss
@@ -2,6 +2,13 @@
 
 .new-registration-container{
   @include form-container;
+  @media screen and (max-width: 700px) {
+    width: 100%;
+  }
+  @media screen and (max-width: 850px) {
+    padding: 20px 10px;
+    width: 100%;
+  }
 
   .registration-title {
     @include form-title;
@@ -12,12 +19,12 @@
   }
 
   .registration-input{
-    width: 40%;
+    width: 50%;
     @media screen and (max-width: 1300px) {
-      width: 65%;
+      width: 70%;
     }
-    @media screen and (max-width: 850px) {
-      width: 100%;
+    @media screen and (max-width: 500px) {
+      width: 95%;
     }
 
     .registration-field input {

--- a/app/assets/stylesheets/custom_session.scss
+++ b/app/assets/stylesheets/custom_session.scss
@@ -8,6 +8,7 @@
   }
   @media screen and (max-width: 800px) {
     width: 100%;
+    padding: 20px 5px;
   }
 
     .session-title{

--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -35,6 +35,9 @@
   .menu-form-container{
     text-align: center;
     width: 60%;
+    @media screen and (max-width: 1200px) {
+      width: 90%;
+    }
     @media screen and (max-width: 700px) {
       width: 100%;
     }
@@ -74,7 +77,7 @@
       padding-bottom: 13px;
       padding-left: 8px;
       margin-top: 7px;
-      font-size: 13px;
+      font-size: 16px;
       margin-bottom: 7px;
       margin-right: 7px;
       border-radius: 20px;
@@ -136,6 +139,7 @@
         .ingredient-unit{
           display: block;
           padding: 10px;
+          font-size: 16px;
           border: 1px solid #ccc;
           @media screen and (max-width: 400px) {
             width: 90%;
@@ -146,7 +150,10 @@
         }
 
         .ingredient-name{
-          width: 380px;
+          width: 350px;
+          @media screen and (max-width: 400px) {
+            width: 120px;
+          }
         }
 
         .ingredient-quantity{

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -1,4 +1,8 @@
 .pagination-container {
+  @media screen and (max-width: 1100px) {
+    height: 200px;
+  }
+
   a {
     display: inline-block;
     margin: 0 10px;

--- a/app/assets/stylesheets/shared/_styles.scss
+++ b/app/assets/stylesheets/shared/_styles.scss
@@ -55,7 +55,7 @@
 @mixin field-form{
   width: 90%;
   padding: 10px 4%;
-  font-size: 13px;
+  font-size: 16px;
   margin-bottom: 13px;
   border-radius: 20px;
   margin-right: 13px;

--- a/app/views/custom_registrations/new.html.erb
+++ b/app/views/custom_registrations/new.html.erb
@@ -14,7 +14,7 @@
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.text_field :name, autofocus: false, name: 'user[name]', autocomplete: "name", placeholder: "ユーザー名（2〜15文字、英数字）" %>
+        <%= f.text_field :name, autofocus: false, name: 'user[name]', autocomplete: "name", placeholder: "ユーザー名:2〜15文字、英数字" %>
       </div>
 
       <div class="registration-field">
@@ -24,7 +24,7 @@
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.password_field :password, autofocus: false, name: 'user[password]', autocomplete: "password", placeholder: "パスワード（8~128文字、英数記号含む）" %>
+        <%= f.password_field :password, autofocus: false, name: 'user[password]', autocomplete: "password", placeholder: "パスワード:8~128文字、英数記号含む" %>
       </div>
 
       <div class="registration-field">

--- a/app/views/custom_sessions/new.html.erb
+++ b/app/views/custom_sessions/new.html.erb
@@ -16,7 +16,7 @@
       </div>
       <div class="session-field">
         <div class="error-message"></div>
-        <%= f.password_field :password, autofocus: false, autocomplete: "new-password", name: 'user[password]', placeholder: "パスワード（8~128文字、英数記号含む）" %>
+        <%= f.password_field :password, autofocus: false, autocomplete: "new-password", name: 'user[password]', placeholder: "パスワード:8~128文字、英数記号含む" %>
       </div>
       <div class="session-actions">
         <%= f.submit "ログイン" %>


### PR DESCRIPTION
目的：
フォーム入力時の視認性を向上させるため、フォントサイズを統一するという目的です。

内容：
・入力フォームのフォントサイズを16pxに変更

新規登録フォーム：
<img width="1440" alt="スクリーンショット 2024-02-06 14 39 09" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/9d6670aa-5158-4a15-a00f-78699a98b858">
<img width="243" alt="スクリーンショット 2024-02-06 15 00 32" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/cd16fbac-0d2a-4585-a710-12d8d249f479">

ログインフォーム：
<img width="1439" alt="スクリーンショット 2024-02-06 15 00 43" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/4bf75e18-da5d-4b9c-9b66-3ad67c0949f3">
<img width="243" alt="スクリーンショット 2024-02-06 15 00 57" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/43755a55-ba6e-481f-a859-6ff523dd3a35">

献立登録フォーム：
<img width="1440" alt="スクリーンショット 2024-02-06 15 02 27" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/9674327a-d82b-4a64-941c-3d031154b217">
<img width="1440" alt="スクリーンショット 2024-02-06 15 02 34" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/9909ca26-bb4d-42e0-867b-1b8db44091e0">
<img width="244" alt="スクリーンショット 2024-02-06 15 02 51" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/278062a8-5487-4736-ae77-f38c516e0d7f">
<img width="242" alt="スクリーンショット 2024-02-06 15 03 02" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/c0f390ae-279b-4ba8-8017-4b9d63a4ac8e">

