### PR TITLE
新機能追加でmenuモデル改修、関連viewとバリデーションを修正

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -35,8 +35,7 @@ class MenusController < ApplicationController
     # 受け取ったmenuデータを再度インスタンス化
     @menu = Menu.new(
       menu_name: params[:menu][:menu_name],
-      menu_contents: params[:menu][:menu_contents],
-      contents: params[:menu][:contents],
+      menu_contents: params[:menu][:menu_contents]
     )
 
     # ingredientデータの処理
@@ -259,14 +258,14 @@ class MenusController < ApplicationController
   private
 
   def menu_params
-    params.require(:menu).permit(:menu_name, :menu_contents, :contents, :encoded_image, :filename, :image_content_type, :image_data_url, ingredients_attributes: [:material_name, :material_id, :quantity, :unit_id])
+    params.require(:menu).permit(:menu_name, :menu_contents, :encoded_image, :filename, :image_content_type, :image_data_url, ingredients_attributes: [:material_name, :material_id, :quantity, :unit_id])
   end
 
   # このメソッドでは、`confirm` アクションからのリダイレクト時に、ストロングパラメータを
   # 使用して、許可された属性（menu_name、menu_contents、contents）をモデルに一括で割り当てる
   # ために必要なパラメータをフィルタリングします。
   def menu_params_from_confirm
-    params.require(:menu).permit(:menu_name, :menu_contents, :contents)
+    params.require(:menu).permit(:menu_name, :menu_contents)
   end
 
   def filter_ingredients(ingredients_params)

--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -7,7 +7,7 @@ document.addEventListener('submit', function(event) {
   let maxForm = 14;
   let menu_name = document.getElementById("menu_name");
   let menu_contents = document.getElementById("menu_contents");
-  let contents = document.getElementById("contents");
+  // let contents = document.getElementById("contents");
   let errorMessage_name = document.getElementById("menu-error_name");
   let errorMessage_menu_contents = document.getElementById("menu-error-menu-contents");
   let errorMessage_contents = document.getElementById("menu-error-contents");
@@ -18,7 +18,7 @@ document.addEventListener('submit', function(event) {
   // menuモデルのバリデーション
   validateAndHighlightInput(menu_name, errorMessage_name, inputName, event)
   validateAndHighlightInput(menu_contents, errorMessage_menu_contents, inputContent, event)
-  validateAndHighlightInput(contents, errorMessage_contents, inputText, event)
+  // validateAndHighlightInput(contents, errorMessage_contents, inputText, event)
 
   // ingredientモデルのバリデーション
   for (let i = minForm; i < maxForm; i++) {

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -11,7 +11,6 @@ class Menu < ApplicationRecord
 
   validates :menu_name, presence: { message: '登録中に予期せぬエラーが発生しました。' }, length: { maximum: 15, message: '登録中に予期せぬエラーが発生しました。' }
   validates :menu_contents, presence: { message: '登録中に予期せぬエラーが発生しました。' }, length: { maximum: 60, message: '登録中に予期せぬエラーが発生しました。' }
-  validates :contents, presence: { message: '登録中に予期せぬエラーが発生しました。' }, length: { maximum: 1500, message: '登録中に予期せぬエラーが発生しました。' }
   before_validation :set_default_image
 
   # モデルのingredientモデルのバリデーション設定

--- a/app/views/menus/_form_fields.html.erb
+++ b/app/views/menus/_form_fields.html.erb
@@ -8,11 +8,6 @@
   <%= f.text_field :menu_contents, autofocus: false, id: "menu_contents", autocomplete: "menu_contents", placeholder: "献立の説明(最大60字)" %>
 </div>
 
-<div id="menu-error-contents" class="menu-error"></div>
-<div class="content-field">
-  <%= f.text_area :contents, autofocus: false, id: "contents", autocomplete: "contents", placeholder: "作り方(最大1500字)" %>
-</div>
-
 <div class="image-field">
   <%= f.file_field :image, autofocus: false, autocomplete: "image", placeholder: "献立の写真", id: "menu_image" %>
 </div>

--- a/app/views/menus/_menu_confirm_details.html.erb
+++ b/app/views/menus/_menu_confirm_details.html.erb
@@ -20,14 +20,6 @@
   </div>
 
   <div class ="contents-title">
-    <p>　作り方　</p>
-  </div>
-  <div class ="menu-contents">
-    <%= simple_format(sanitize(menu.contents)) %>
-    <%= f.hidden_field :contents, value: menu.contents %>
-  </div>
-
-  <div class ="contents-title">
     <p>　献立画像　</p>
   </div>
   <div class ="menu-contents">

--- a/app/views/menus/_review_edit_menu_fields.html.erb
+++ b/app/views/menus/_review_edit_menu_fields.html.erb
@@ -1,6 +1,5 @@
 <%= f.hidden_field :menu_name, value: menu.menu_name %>
 <%= f.hidden_field :menu_contents, value: menu.menu_contents %>
-<%= f.hidden_field :contents, value: menu.contents %>
 <%= f.hidden_field :encoded_image, value: encoded_image %>
 <%= f.hidden_field :filename, value: menu.image.filename.to_s %>
 <%= f.hidden_field :image_content_type, value: menu.image.content_type %>

--- a/app/views/shared/_menu_details.html.erb
+++ b/app/views/shared/_menu_details.html.erb
@@ -20,13 +20,6 @@
   </div>
 
   <div class="show-contents-title">
-    <p>　作り方　</p>
-  </div>
-  <div class="menu-contents">
-    <%= simple_format(sanitize(menu.contents)) %>
-  </div>
-
-  <div class="show-contents-title">
     <p>　献立画像　</p>
   </div>
 

--- a/db/migrate/20230906091255_create_menus.rb
+++ b/db/migrate/20230906091255_create_menus.rb
@@ -3,7 +3,6 @@ class CreateMenus < ActiveRecord::Migration[7.0]
     create_table :menus do |t|
       t.string :menu_name,               null: false, default: ""
       t.text :menu_contents,             null: false, default: ""
-      t.string :contents,                null: false, default: ""
       t.text :image_meta_data,           null: false, default: ""
       t.string :image,                   null: false, default: ""
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -121,7 +121,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_15_010902) do
   create_table "menus", force: :cascade do |t|
     t.string "menu_name", default: "", null: false
     t.text "menu_contents", default: "", null: false
-    t.string "contents", default: "", null: false
     t.text "image_meta_data", default: "", null: false
     t.string "image", default: "", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
目的：
新機能の導入により、menuモデルから「contents」カラムを削除し、システムの整合性を保つための更新を行うという目的です。

内容：
・menuモデルの「contents」カラムを削除
・関連するviewファイルのコードを修正
・jsによるフォームバリデーションのコードを修正
・menuコントローラーのコードを修正