### PR TITLE
作り方の工程保存機能とmenu_idなしのバリデーションを実装

### DIFF
--- a/app/assets/stylesheets/menu/_menu_edit_confirmation_fields.scss
+++ b/app/assets/stylesheets/menu/_menu_edit_confirmation_fields.scss
@@ -2,4 +2,24 @@
 
 .menu-confirm-container{
   @include flex-center-column;
+
+  .recipe-step-contents {
+    margin-bottom: 20px;
+
+    .step-header {
+      display: flex;
+      align-items: center;
+      justify-content: start;
+
+      .step-order,
+      .step-category-name {
+        margin-right: 10px;
+      }
+
+      // 必要に応じて各項目のスタイルを追加
+      .step-order {
+        font-weight: bold;
+      }
+    }
+  }
 }

--- a/app/javascript/dynamic_step_forms.js
+++ b/app/javascript/dynamic_step_forms.js
@@ -65,6 +65,8 @@ function createNewStepForm() {
   const displayOffset = FORM_INDEX_OFFSET;
   let newFormCount_view = stepFormCountView + displayOffset;
 
+  let stepFormCount_Back = stepFormCountBack + displayOffset;
+
   const twoDigitThreshold = TWO_DIGIT_DISPLAY_THRESHOLD;
   let paddedNewFormCount = newFormCount_view < twoDigitThreshold ? '0' + newFormCount_view : newFormCount_view;
 
@@ -74,7 +76,7 @@ function createNewStepForm() {
     <div class="step-form-field">
 
       <div class="step-delete-button">
-        <a href="#" class="step-form-count-down" data-action="decrement",  id="step-form-count-down[${stepFormCountBack}]">❌</a>
+        <a href="#" class="step-form-count-down" data-action="decrement",  id="step-form-count-down[${stepFormCount_Back}]">❌</a>
       </div>
 
       <div class="step-field-wrapper">
@@ -84,7 +86,7 @@ function createNewStepForm() {
 
         <div class="step-fields">
           <div class="step-category-dropdown">
-            <select name="steps[${stepFormCountBack}][category_id]" class="select-dropdown">
+            <select name="menu[recipe_steps][${stepFormCount_Back}][recipe_step_category_id]" class="select-dropdown">
               <option value="">工程ジャンルを選択してください。</option>
               <option value="1">野菜の下準備（切る/剥くなど）</option>
               <option value="2">肉の下準備（切る/解凍など）</option>
@@ -94,7 +96,7 @@ function createNewStepForm() {
             </select>
           </div>
           <div class="step-description">
-            <textarea name="steps[${stepFormCountBack}][notes]" maxlength="60" class="text-field" placeholder="メモ（最大60文字）" rows="2"></textarea>
+            <textarea name="menu[recipe_steps][${stepFormCount_Back}][description]" maxlength="60" class="text-field" placeholder="メモ（最大60文字）" rows="2"></textarea>
           </div>
         </div>
       </div>

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -4,16 +4,15 @@ class Ingredient < ApplicationRecord
   belongs_to :material
   belongs_to :unit
 
-  validates :material_name, presence: { message: '登録中に予期せぬエラーが発生しました。' }
-  validates :material_id, presence: { message: '登録中に予期せぬエラーが発生しました。' }
+  common_error_message = '登録中に予期せぬエラーが発生しました。'
 
+  validates :material_name, presence: { message: common_error_message }
+  validates :material_id, presence: { message: common_error_message }
   # 'quantity'は10桁まで許容。小数点含むためと、合算時の桁数考慮のため
-  validates :quantity, presence: { message: '登録中に予期せぬエラーが発生しました。' }, length: { maximum: 10, too_long: '登録中に予期せぬエラーが発生しました。' }, unless: :skip_quantity_validation?
-
-  validates :unit_id, presence: { message: '登録中に予期せぬエラーが発生しました。' }
+  validates :quantity, presence: { message: common_error_message }, length: { maximum: 10, too_long: common_error_message }, unless: :skip_quantity_validation?
+  validates :unit_id, presence: { message: common_error_message }
 
   private
-
   # 特定の条件下で'quantity'バリデーションをスキップ
   def skip_quantity_validation?
     settings = YAML.load_file(Rails.root.join('config', 'settings.yml'))

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -10,15 +10,18 @@ class Menu < ApplicationRecord
   has_many :completed_menus, dependent: :destroy
   has_many :recipe_steps, dependent: :destroy
 
-  validates :menu_name, presence: { message: '登録中に予期せぬエラーが発生しました。' }, length: { maximum: 15, message: '登録中に予期せぬエラーが発生しました。' }
-  validates :menu_contents, presence: { message: '登録中に予期せぬエラーが発生しました。' }, length: { maximum: 60, message: '登録中に予期せぬエラーが発生しました。' }
+  # 全てのバリデーションエラーメッセージを統一
+  common_error_message = '登録中に予期せぬエラーが発生しました。'
+
+  validates :menu_name, presence: { message: common_error_message }, length: { maximum: 15, message: common_error_message }
+  validates :menu_contents, presence: { message: common_error_message }, length: { maximum: 60, message: common_error_message }
   before_validation :set_default_image
 
-  # モデルのingredientモデルのバリデーション設定
   validate :validate_ingredients
+  validate :validate_recipe_steps
 
   # 複数のingredientデータを格納するために設定しています。
-  attr_accessor :ingredients, :encoded_image, :image_content_type, :image_data_url, :steps
+  attr_accessor :ingredients, :encoded_image, :image_content_type, :image_data_url, :recipe_steps
 
   private
 
@@ -35,6 +38,16 @@ class Menu < ApplicationRecord
         ingredient.errors.full_messages.each do |message|
           errors.add(:base, message)
         end
+      end
+    end
+  end
+
+  def validate_recipe_steps
+    recipe_steps.each do |recipe_step|
+      next if recipe_step.valid?
+
+      recipe_step.errors.full_messages.each do |message|
+        errors.add(:base, message)
       end
     end
   end

--- a/app/models/recipe_step.rb
+++ b/app/models/recipe_step.rb
@@ -1,4 +1,24 @@
 class RecipeStep < ApplicationRecord
-  belongs_to :menu
+  belongs_to :menu, optional: true
   belongs_to :recipe_step_category
+
+  # 全てのバリデーションエラーメッセージを統一
+  common_error_message = '登録中に予期せぬエラーが発生しました。'
+
+  validates :recipe_step_category_id, presence: { message: common_error_message }
+  validates :description, presence: { message: common_error_message }, length: { maximum: 60, message: common_error_message }
+  # コールバックを使用してstep_orderを自動設定
+  before_validation :set_step_order, on: :create
+
+  private
+
+  def set_step_order
+    settings = YAML.load_file(Rails.root.join('config', 'settings.yml'))
+    initial_step_order = settings.dig('recipe_step', 'initial_step_order')
+    step_order_increment = settings.dig('recipe_step', 'step_order_increment')
+
+    # 現在のmenu_idに属する最後のstep_orderを取得し、1を加算する
+    # 現在のメニューに属するレシピステップがない場合は1を設定
+    self.step_order = (RecipeStep.where(menu_id: menu_id).maximum(:step_order) || initial_step_order) + step_order_increment
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,12 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :menu_users, dependent: :destroy
+  has_many :menus, through: :menu_users
+  has_one :cart, dependent: :destroy
+  has_many :completed_menus, dependent: :destroy
+  has_many :shopping_lists, dependent: :destroy
+  has_many :completed_menus, dependent: :destroy
 
   validates :name, presence: { message: "ユーザー名は必須です。" },
   length: { minimum: 2, too_short: "ユーザー名は最低%{count}文字必要です。", maximum: 15, too_long: "ユーザー名は最大%{count}文字までです。" },
@@ -21,13 +27,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :confirmable
   attr_accessor :current_password, :user_info_change, :password_change, :new_record, :email_change
-
-  has_many :menu_users, dependent: :destroy
-  has_many :menus, through: :menu_users
-  has_one :cart, dependent: :destroy
-  has_many :completed_menus, dependent: :destroy
-  has_many :shopping_lists, dependent: :destroy
-  has_many :completed_menus, dependent: :destroy
 
   private
 

--- a/app/views/menus/_menu_confirm_details.html.erb
+++ b/app/views/menus/_menu_confirm_details.html.erb
@@ -36,6 +36,36 @@
       <p>画像なし</p>
     <% end %>
   </div>
+
+
+  <div class ="contents-title">
+    <p>　作り方　</p>
+  </div>
+  <% if recipe_steps.present? %>
+    <% recipe_steps.each_with_index do |step, index| %>
+      <div class ="recipe-step-contents">
+        <div class="step-header">
+          <div class="step-order">
+            <p><%= index + 1 %></p>
+          </div>
+          <div class="step-category-name">
+            <p><%= step.recipe_step_category.name %></p>
+          </div>
+        </div>
+        <div class="step-description">
+          <p><%= step.description %></p>
+        </div>
+      </div>
+    <% end %>
+
+    <% if menu.recipe_steps.present? %>
+      <% menu.recipe_steps.each_with_index do |recipe_step, index| %>
+        <%= f.hidden_field "recipe_steps[#{index}][description]", value: recipe_step.description %>
+        <%= f.hidden_field "recipe_steps[#{index}][recipe_step_category_id]", value: recipe_step.recipe_step_category_id %>
+      <% end %>
+    <% end %>
+  <% end %>
+
 </div>
 
 <div class="ingredient-confirm-container">

--- a/app/views/menus/_review_edit_menu_fields.html.erb
+++ b/app/views/menus/_review_edit_menu_fields.html.erb
@@ -5,6 +5,13 @@
 <%= f.hidden_field :image_content_type, value: menu.image.content_type %>
 <%= f.hidden_field :image_data_url, value: image_data_url %>
 
+<% if menu.recipe_steps.present? %>
+  <% menu.recipe_steps.each_with_index do |recipe_step, index| %>
+    <%= f.hidden_field "recipe_steps_attributes[#{index}][description]", value: recipe_step.description %>
+    <%= f.hidden_field "recipe_steps_attributes[#{index}][recipe_step_category_id]", value: recipe_step.recipe_step_category_id %>
+  <% end %>
+<% end %>
+
 <% if menu.ingredients.present? %>
   <% menu.ingredients.each_with_index do |ingredient, index| %>
     <%= f.hidden_field "ingredients_attributes[#{index}][material_name]", value: ingredient.material_name %>

--- a/app/views/menus/edit_confirm.html.erb
+++ b/app/views/menus/edit_confirm.html.erb
@@ -3,7 +3,7 @@
 
     <%= form_with model: @menu, url: user_menu_path(id: current_user.id, menu_id: @menu.id), method: :patch, local: true do |f| %>
       <%= f.hidden_field :menu_id, value: params[:menu][:menu_id] %>
-      <%= render 'menu_confirm_details', f: f, menu: @menu, image_data_url: @image_data_url, encoded_image: @encoded_image,
+      <%= render 'menu_confirm_details', f: f, menu: @menu, recipe_steps: @menu.recipe_steps, image_data_url: @image_data_url, encoded_image: @encoded_image,
       image_content_type: @image_content_type, ingredients: @menu.ingredients, button_text: "更新" %>
     <% end %>
 
@@ -11,7 +11,7 @@
       <div class="menu-edit-button">
         <%= form_with model: @menu, url: edit_confirm_user_menus_path(current_user, id: @menu.id), method: :post, local: true do |f| %>
           <%= f.hidden_field :menu_id, value: params[:menu][:menu_id] %>
-          <%= render 'review_edit_menu_fields', f: f, menu: @menu, encoded_image: @encoded_image, image_data_url: @image_data_url %>
+          <%= render 'review_edit_menu_fields', f: f, menu: @menu, recipe_steps: @menu.recipe_steps, encoded_image: @encoded_image, image_data_url: @image_data_url %>
         <% end %>
       </div>
     </div>

--- a/app/views/menus/new_confirm.html.erb
+++ b/app/views/menus/new_confirm.html.erb
@@ -2,15 +2,14 @@
   <div class="confirm-form-container">
 
     <%= form_with model: @menu, url: user_menus_path(current_user), method: :post, local: true do |f| %>
-      <%= render 'menu_confirm_details', f: f, menu: @menu, image_data_url: @image_data_url, encoded_image: @encoded_image,
+      <%= render 'menu_confirm_details', f: f, menu: @menu, recipe_steps: @menu.recipe_steps, image_data_url: @image_data_url, encoded_image: @encoded_image,
       image_content_type: @image_content_type, ingredients: @menu.ingredients, button_text: "登録" %>
     <% end %>
-
 
     <div class="button-confirm-container">
       <div class="menu-edit-button">
         <%= form_with model: @menu, url: new_user_menu_path(current_user), method: :post, local: true do |f| %>
-          <%= render 'review_edit_menu_fields', f: f, menu: @menu, encoded_image: @encoded_image, image_data_url: @image_data_url %>
+          <%= render 'review_edit_menu_fields', f: f, menu: @menu, recipe_steps: @menu.recipe_steps, encoded_image: @encoded_image, image_data_url: @image_data_url %>
         <% end %>
       </div>
     </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,3 +20,7 @@ confirmation:
 
 cart:
   default_item_count_decrement: 1
+
+recipe_step:
+  initial_step_order: 0
+  step_order_increment: 1


### PR DESCRIPTION
目的：
作り方の工程を保存できるよう設定し、menu_idが未設定の状態でも工程データのバリデーションが可能になるようにすることが目的です。

内容：
・作り方の工程を保存する機能を実装
・モデルファイルで作り方の工程データ保存時のバリデーション設定
・recipe_step.rbでのバリデーションでは「belongs_to :menu, optional: true」と設定
