### PR TITLE
確認後の再編集で献立登録内容が正しく反映される修正

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -38,6 +38,10 @@ class MenusController < ApplicationController
       menu_contents: params[:menu][:menu_contents]
     )
 
+    if params[:menu][:recipe_steps_attributes]
+      @menu.recipe_steps = params[:menu][:recipe_steps_attributes]
+    end
+
     # ingredientデータの処理
     # 別途子モデルであるingredientsをmenuに別途割り当てる。
     # 理由は「accepts_nested_attributes_for」を使用しないためです。

--- a/app/javascript/add_form.js
+++ b/app/javascript/add_form.js
@@ -177,9 +177,9 @@ function createNewForms(defaultMaxCount, Data, unitIds){
 function updateForm(){
   let ingredientsDate = document.getElementById('ingredients-date');
   // data-ingredients 属性の値を取得
-  let dataAttr = ingredientsDate.getAttribute('data-ingredients');
+  let ingredientsDataAttribute = ingredientsDate.getAttribute('data-ingredients');
   // JSON文字列をオブジェクトに変換
-  let parsedIngredients = JSON.parse(dataAttr);
+  let parsedIngredients = JSON.parse(ingredientsDataAttribute);
 
   // 食材未登録の状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
   if (parsedIngredients === null) {
@@ -189,7 +189,6 @@ function updateForm(){
     createNewForms(maxCount, {});
     return;
   }
-
 
   // 配列のインデックスに対応する単位IDを格納するオブジェクトを作成
   let unitIds = {};

--- a/app/javascript/add_form.js
+++ b/app/javascript/add_form.js
@@ -125,8 +125,8 @@ function updateMaxCountText(ingredientFormCountView, ingredientMaxFormCountView)
   formCountLimit.textContent = "+作成（あと" + countLimit + "個）";
 }
 
-function createNewForms(defaultMaxCount, Data, unitIds){
-  for (let i = 0; i < defaultMaxCount ; i++) {
+function createNewForms(defaultCount, Data, unitIds){
+  for (let i = 0; i < defaultCount ; i++) {
     createNewForm();
 
     // Dataが存在しない、またはData[i]が存在しない場合、以降の処理をスキップ
@@ -208,14 +208,14 @@ function updateForm(){
 
   // 献立を設定された状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
   if (formCount >= minFormCount) {
-    const maxCount = formCount
-    createNewForms(maxCount, parsedIngredients, unitIds)
+    const createFormCount = formCount
+    createNewForms(createFormCount, parsedIngredients, unitIds)
 
   // 新規で登録フォームを表示する場合の処理
   }else{
     // 新規で登録フォームを表示する場合、デフォルトのフォーム数（ここでは5）を設定してフォームを生成
-    const maxCount = INGREDIENT_DEFAULT_NEW_FORM_COUNT
-    createNewForms(maxCount, parsedIngredients, unitIds)
+    const defaultFormCount = INGREDIENT_DEFAULT_NEW_FORM_COUNT
+    createNewForms(defaultFormCount, parsedIngredients, unitIds)
   }
 }
 

--- a/app/javascript/dynamic_step_forms.js
+++ b/app/javascript/dynamic_step_forms.js
@@ -102,61 +102,6 @@ function createNewStepForms(defaultMaxCount, Data){
   updateMaxStepCountText(stepFormCountView, maxStepFormCountView)
 }
 
-
-// // 一時的に設定
-// function createNewForms(defaultMaxCount, Data, unitIds){
-//   for (let i = 0; i < defaultMaxCount ; i++) {
-//     createNewForm();
-
-//     // Dataが存在しない、またはData[i]が存在しない場合、以降の処理をスキップ
-//     if (!Data || !Data[i]) continue;
-//     let currentData = Data[i];
-//     let currentForm = document.querySelectorAll('.custom-ingredient-fields')[i];
-
-//     let ingredientNameField = currentForm.querySelector(`#ingredient_name\\[${i}\\]`);
-//     let ingredientIdField = currentForm.querySelector(`#ingredient_id\\[${i}\\]`);
-//     let ingredientQuantityField = currentForm.querySelector(`#ingredient_quantity\\[${i}\\]`);
-
-//     // 材料名、数量、単位IDを設定
-//     if (ingredientNameField) {
-//       // readonly 属性を一時的に解除
-//       ingredientNameField.removeAttribute('readonly');
-//       // 値を設定
-//       ingredientNameField.value = currentData.material_name || '';
-//       // 再び readonly 属性を設定
-//       ingredientNameField.setAttribute('readonly', true);
-//     }
-
-//     if (ingredientIdField) ingredientIdField.value = currentData.material_id || '';
-
-//     if (ingredientQuantityField) {
-//       // formatQuantity関数を使用して数量を整形してから設定
-//       ingredientQuantityField.value = formatQuantity(currentData.quantity) || '';
-//     }
-
-//     let ingredientUnitSelect = currentForm.querySelector(`#menu_ingredients_unit\\[${i}\\]`);
-
-//     if (ingredientUnitSelect && unitIds[i]) {
-//       // 単位のセットアップ
-//       handleIngredientNameChange(ingredientUnitSelect, currentData.material_name, unitIds[i]);
-
-//       // 選択された単位IDを適用するための遅延。DOMの更新後に単位を設定するために必要。
-//       const unitSelectionDelay = UNIT_SELECTION_DELAY_MS;
-
-//       // 既に選択されている単位IDがあれば、それを選択する
-//       // この処理には動的フォーム作成＋単位設定処理を行った後に処理される必要があるため、あえて遅延させています。
-//       setTimeout(() => {
-//         ingredientUnitSelect.value = currentData.unit_id || '';
-//       }, unitSelectionDelay);
-//     }
-//   }
-//   updateMaxCountText(ingredientFormCountView, ingredientMaxFormCountView)
-// }
-
-
-
-
-
 // フォームにあるフォーム追加ボタンで表示されるカウントについての処理
 function updateMaxStepCountText(stepFormCountView, maxStepFormCountView) {
   // formCountLimit 要素を取得

--- a/app/javascript/dynamic_step_forms.js
+++ b/app/javascript/dynamic_step_forms.js
@@ -14,6 +14,10 @@ var FORM_INDEX_OFFSET = 1;
 var TWO_DIGIT_DISPLAY_THRESHOLD = 10;
 // デフォルトで表示されるフォームの最大数
 var DEFAULT_MAX_FORM_COUNT = 5;
+// 工程未登録時に生成するフォームの数
+var INGREDIENT_NO_FORM_STEPS_COUNT = 0;
+// フォームが少なくとも1つ存在することを示す最小フォームカウント
+var INGREDIENT_MIN_FORM_STEPS_COUNT = 1;
 
 var stepFormCountView = INITIAL_FORM_COUNT_VIEW;
 var stepFormCountBack = INITIAL_FORM_COUNT_BACK;
@@ -38,15 +42,120 @@ document.addEventListener("click", function(event) {
 
 function updateStepForm(){
   const maxStepCount = DEFAULT_MAX_FORM_COUNT;
-  createNewForms(maxStepCount)
+  let stepsDate = document.getElementById('steps-date');
+  // data-ingredients 属性の値を取得
+  let stepsDataAttribute = stepsDate.getAttribute('data-steps');
+  // JSON文字列をオブジェクトに変換
+  let parsedSteps = JSON.parse(stepsDataAttribute);
+
+  // 食材未登録の状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
+  if (parsedSteps === null) {
+    // maxCount: 新しく生成するフォームの数を指定。
+    // ここでは食材が未登録のため、0に設定してフォームを生成しない。
+    const maxStepCount = DEFAULT_MAX_FORM_COUNT;
+    createNewStepForms(maxStepCount)
+    return;
+  }
+
+  // parsedSteps から null でない値のみを抽出し、その数をカウント
+  let formStepCount = Object.values(parsedSteps).filter(value => value !== null).length;
+  // 最小フォームカウント：この値は、フォームが存在している（つまりフォームの数が0より大きい）ことを確認するために使用される。
+  // 1は、少なくとも1つのフォームが存在することを意味し、この条件を満たした場合のみフォームの再作成を行う。
+  const minFormStepCount = INGREDIENT_MIN_FORM_STEPS_COUNT;
+
+  // 献立を設定された状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
+  if (formStepCount >= minFormStepCount) {
+    // 編集時に設定されていたフォームの数を設定
+    const StepCount = formStepCount
+    createNewStepForms(StepCount, parsedSteps)
+
+  // 新規で登録フォームを表示する場合の処理
+  }else{
+    // 新規で登録フォームを表示する場合、デフォルトのフォーム数（ここでは5）を設定してフォームを生成
+    const defaultStepCount = DEFAULT_MAX_FORM_COUNT
+    createNewStepForms(defaultStepCount, parsedSteps)
+  }
 }
 
-function createNewForms(defaultMaxCount){
+function createNewStepForms(defaultMaxCount, Data){
   for (var i = 0; i < defaultMaxCount ; i++) {
     createNewStepForm()
+    // Dataが存在しない、またはData[i]が存在しない場合、以降の処理をスキップ
+    if (!Data || !Data[i]) continue;
+    let currentStepData = Data[i];
+    let currentStepForm = document.querySelectorAll('.step-form-field')[i];
+    // ステップカテゴリIDを取得するためのセレクタ
+    let stepCategoryField = currentStepForm .querySelector(`#recipe_step_category_id\\[${i}\\]`);
+    // ステップの説明を取得するためのセレクタ
+    let stepDescriptionField = currentStepForm .querySelector(`#recipe_steps_description\\[${i}\\]`);
+
+    // ステップカテゴリIDを設定
+    if (stepCategoryField && currentStepData.recipe_step_category_id) {
+      stepCategoryField.value = currentStepData.recipe_step_category_id;
+    }
+
+    // ステップの説明を設定
+    if (stepDescriptionField && currentStepData.description) {
+      stepDescriptionField.value = currentStepData.description;
+    }
   }
   updateMaxStepCountText(stepFormCountView, maxStepFormCountView)
 }
+
+
+// // 一時的に設定
+// function createNewForms(defaultMaxCount, Data, unitIds){
+//   for (let i = 0; i < defaultMaxCount ; i++) {
+//     createNewForm();
+
+//     // Dataが存在しない、またはData[i]が存在しない場合、以降の処理をスキップ
+//     if (!Data || !Data[i]) continue;
+//     let currentData = Data[i];
+//     let currentForm = document.querySelectorAll('.custom-ingredient-fields')[i];
+
+//     let ingredientNameField = currentForm.querySelector(`#ingredient_name\\[${i}\\]`);
+//     let ingredientIdField = currentForm.querySelector(`#ingredient_id\\[${i}\\]`);
+//     let ingredientQuantityField = currentForm.querySelector(`#ingredient_quantity\\[${i}\\]`);
+
+//     // 材料名、数量、単位IDを設定
+//     if (ingredientNameField) {
+//       // readonly 属性を一時的に解除
+//       ingredientNameField.removeAttribute('readonly');
+//       // 値を設定
+//       ingredientNameField.value = currentData.material_name || '';
+//       // 再び readonly 属性を設定
+//       ingredientNameField.setAttribute('readonly', true);
+//     }
+
+//     if (ingredientIdField) ingredientIdField.value = currentData.material_id || '';
+
+//     if (ingredientQuantityField) {
+//       // formatQuantity関数を使用して数量を整形してから設定
+//       ingredientQuantityField.value = formatQuantity(currentData.quantity) || '';
+//     }
+
+//     let ingredientUnitSelect = currentForm.querySelector(`#menu_ingredients_unit\\[${i}\\]`);
+
+//     if (ingredientUnitSelect && unitIds[i]) {
+//       // 単位のセットアップ
+//       handleIngredientNameChange(ingredientUnitSelect, currentData.material_name, unitIds[i]);
+
+//       // 選択された単位IDを適用するための遅延。DOMの更新後に単位を設定するために必要。
+//       const unitSelectionDelay = UNIT_SELECTION_DELAY_MS;
+
+//       // 既に選択されている単位IDがあれば、それを選択する
+//       // この処理には動的フォーム作成＋単位設定処理を行った後に処理される必要があるため、あえて遅延させています。
+//       setTimeout(() => {
+//         ingredientUnitSelect.value = currentData.unit_id || '';
+//       }, unitSelectionDelay);
+//     }
+//   }
+//   updateMaxCountText(ingredientFormCountView, ingredientMaxFormCountView)
+// }
+
+
+
+
 
 // フォームにあるフォーム追加ボタンで表示されるカウントについての処理
 function updateMaxStepCountText(stepFormCountView, maxStepFormCountView) {
@@ -86,7 +195,7 @@ function createNewStepForm() {
 
         <div class="step-fields">
           <div class="step-category-dropdown">
-            <select name="menu[recipe_steps][${stepFormCount_Back}][recipe_step_category_id]" class="select-dropdown">
+            <select id="recipe_step_category_id[${stepFormCount_Back}]" name="menu[recipe_steps][${stepFormCount_Back}][recipe_step_category_id]" class="select-dropdown">
               <option value="">工程ジャンルを選択してください。</option>
               <option value="1">野菜の下準備（切る/剥くなど）</option>
               <option value="2">肉の下準備（切る/解凍など）</option>
@@ -96,7 +205,7 @@ function createNewStepForm() {
             </select>
           </div>
           <div class="step-description">
-            <textarea name="menu[recipe_steps][${stepFormCount_Back}][description]" maxlength="60" class="text-field" placeholder="メモ（最大60文字）" rows="2"></textarea>
+            <textarea id="recipe_steps_description[${stepFormCount_Back}]" name="menu[recipe_steps][${stepFormCount_Back}][description]" maxlength="60" class="text-field" placeholder="メモ（最大60文字）" rows="2"></textarea>
           </div>
         </div>
       </div>

--- a/app/javascript/dynamic_step_forms.js
+++ b/app/javascript/dynamic_step_forms.js
@@ -77,8 +77,8 @@ function updateStepForm(){
   }
 }
 
-function createNewStepForms(defaultMaxCount, Data){
-  for (var i = 0; i < defaultMaxCount ; i++) {
+function createNewStepForms(createFormCount, Data){
+  for (var i = 0; i < createFormCount ; i++) {
     createNewStepForm()
     // Dataが存在しない、またはData[i]が存在しない場合、以降の処理をスキップ
     if (!Data || !Data[i]) continue;

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -26,6 +26,8 @@
           <p>２.作り方の設定</p>
         </div>
 
+        <div id ="steps-date", data-steps="<%= @menu.recipe_steps.to_json %>"></div>
+
         <div class="steps-form-input" id="steps-form-input">
           <%= f.fields_for :steps do |step_form| %>
             <div id="step_form"></div>
@@ -73,7 +75,7 @@
   <div id="dropdownBackground" class="dropdown-bg"></div>
 </div>
 
-  <%= javascript_include_tag 'addForm' %>
+  <%= javascript_include_tag 'add_form' %>
   <%= javascript_include_tag 'ingredient_dropdown' %>
   <%= javascript_include_tag 'menu_validation' %>
   <%= javascript_include_tag 'image_preview' %>


### PR DESCRIPTION
目的：
新規献立登録フォームから確認画面に移動した後、再編集を行った際にユーザーの入力内容が正しくフォームに表示されるようにすることが目的です。

内容：
・確認画面から編集画面へ戻った時の入力内容の保持処理を改善
・再編集時にユーザー入力値が正確に表示される機能を追加

<img width="850" alt="スクリーンショット 2024-02-12 0 30 06" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/bd73dc96-e4ab-4e71-9000-a668908ae6cb">
