### PR TITLE
既存の献立の再編集が正しく反映されるよう設定

### DIFF
--- a/app/assets/stylesheets/menu/_menu_edit_confirmation_fields.scss
+++ b/app/assets/stylesheets/menu/_menu_edit_confirmation_fields.scss
@@ -3,22 +3,46 @@
 .menu-confirm-container{
   @include flex-center-column;
 
-  .recipe-step-contents {
-    margin-bottom: 20px;
-
-    .step-header {
-      display: flex;
-      align-items: center;
-      justify-content: start;
-
-      .step-order,
-      .step-category-name {
-        margin-right: 10px;
+  .recipe-step-container{
+    width: 70%;
+    @media screen and (max-width: 500px) {
+      width: 100%;
+    }
+    .recipe-step-contents {
+      width: 100%;
+      margin-bottom: 20px;
+      text-align: left;
+      border: 1px solid #ccc;
+      padding: 10px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      @media screen and (max-width: 500px) {
+        padding-left: 0;
+        padding-right: 0;
+        text-align: center;
       }
 
-      // 必要に応じて各項目のスタイルを追加
-      .step-order {
-        font-weight: bold;
+      .step-header {
+        display: flex;
+        align-items: center;
+        justify-content: start;
+  
+        .step-order,
+        .step-category-name {
+          font-size: 18px;
+          margin-right: 10px;
+          @media screen and (max-width: 500px) {
+            margin-left: 10px;
+          }
+        }
+
+        .step-description {
+          word-wrap: break-word;
+        }
+
+        // 必要に応じて各項目のスタイルを追加
+        .step-order {
+          font-weight: bold;
+        }
       }
     }
   }

--- a/app/javascript/add_form.js
+++ b/app/javascript/add_form.js
@@ -120,7 +120,6 @@ function updateMaxCountText(ingredientFormCountView, ingredientMaxFormCountView)
 
   // 作成可能なフォームの残り数を計算
   let countLimit = ingredientMaxFormCountView - ingredientFormCountView;
-
   // formCountLimit 要素のテキストを更新して、残りのフォーム数を表示
   formCountLimit.textContent = "+作成（あと" + countLimit + "個）";
 }

--- a/app/javascript/dynamic_step_forms.js
+++ b/app/javascript/dynamic_step_forms.js
@@ -50,9 +50,6 @@ function updateStepForm(){
 
   // 食材未登録の状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
   if (parsedSteps === null) {
-    // maxCount: 新しく生成するフォームの数を指定。
-    // ここでは食材が未登録のため、0に設定してフォームを生成しない。
-    const maxStepCount = DEFAULT_MAX_FORM_COUNT;
     createNewStepForms(maxStepCount)
     return;
   }
@@ -62,7 +59,6 @@ function updateStepForm(){
   // 最小フォームカウント：この値は、フォームが存在している（つまりフォームの数が0より大きい）ことを確認するために使用される。
   // 1は、少なくとも1つのフォームが存在することを意味し、この条件を満たした場合のみフォームの再作成を行う。
   const minFormStepCount = INGREDIENT_MIN_FORM_STEPS_COUNT;
-
   // 献立を設定された状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
   if (formStepCount >= minFormStepCount) {
     // 編集時に設定されていたフォームの数を設定

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -33,16 +33,20 @@ class Menu < ApplicationRecord
   end
 
   def validate_ingredients
+    return if !ingredients.present?
+
     ingredients.each do |ingredient|
-      if !ingredient.valid?
-        ingredient.errors.full_messages.each do |message|
-          errors.add(:base, message)
-        end
+      next if ingredient.valid?
+
+      ingredient.errors.full_messages.each do |message|
+        errors.add(:base, message)
       end
     end
   end
 
   def validate_recipe_steps
+    return if !recipe_steps.present?
+
     recipe_steps.each do |recipe_step|
       next if recipe_step.valid?
 

--- a/app/views/menus/_menu_confirm_details.html.erb
+++ b/app/views/menus/_menu_confirm_details.html.erb
@@ -43,25 +43,27 @@
   </div>
   <% if recipe_steps.present? %>
     <% recipe_steps.each_with_index do |step, index| %>
-      <div class ="recipe-step-contents">
-        <div class="step-header">
-          <div class="step-order">
-            <p><%= index + 1 %></p>
+      <div class ="recipe-step-container">
+        <div class ="recipe-step-contents">
+          <div class="step-header">
+            <div class="step-order">
+              <p><%= index + 1 %></p>
+            </div>
+            <div class="step-category-name">
+              <p><%= step.recipe_step_category.name %></p>
+            </div>
           </div>
-          <div class="step-category-name">
-            <p><%= step.recipe_step_category.name %></p>
+          <div class="step-description">
+            <p><%= step.description %></p>
           </div>
-        </div>
-        <div class="step-description">
-          <p><%= step.description %></p>
         </div>
       </div>
     <% end %>
 
     <% if menu.recipe_steps.present? %>
       <% menu.recipe_steps.each_with_index do |recipe_step, index| %>
-        <%= f.hidden_field "recipe_steps[#{index}][description]", value: recipe_step.description %>
         <%= f.hidden_field "recipe_steps[#{index}][recipe_step_category_id]", value: recipe_step.recipe_step_category_id %>
+        <%= f.hidden_field "recipe_steps[#{index}][description]", value: recipe_step.description %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/menus/edit.html.erb
+++ b/app/views/menus/edit.html.erb
@@ -27,6 +27,22 @@
         <% end %>
 
         <div class ="contents-title">
+          <p>２.作り方の設定</p>
+        </div>
+
+        <div id ="steps-date", data-steps="<%= @menu.recipe_steps.to_json %>"></div>
+
+        <div class="steps-form-input" id="steps-form-input">
+          <%= f.fields_for :steps do |step_form| %>
+            <div id="step_form"></div>
+          <% end %>
+
+          <div class="step-count-up-button">
+            <button class="step-form-count-up" data-action="increment" id="step-form-count-up"><span id="step-form-count-limit"></span></button>
+          </div>
+        </div>
+
+        <div class ="contents-title">
           <p>２.食材リスト設定</p>
         </div>
 
@@ -44,7 +60,7 @@
           </div>
 
           <div class="count-up-button">
-            <button class="form-count-up" data-action="increment" id="form-count-up"><span id="formCountLimit"></span></button>
+            <button class="form-count-up" data-action="increment" id="form-count-up"><span id="form-count-limit"></span></button>
           </div>
         </div>
 
@@ -63,7 +79,8 @@
   <div id="dropdownBackground" class="dropdown-bg"></div>
 </div>
 
-  <%= javascript_include_tag 'addForm' %>
-  <%= javascript_include_tag 'ingredient_dropdown' %>
-  <%= javascript_include_tag 'menu_validation' %>
-  <%= javascript_include_tag 'image_preview' %>
+<%= javascript_include_tag 'add_form' %>
+<%= javascript_include_tag 'ingredient_dropdown' %>
+<%= javascript_include_tag 'menu_validation' %>
+<%= javascript_include_tag 'image_preview' %>
+<%= javascript_include_tag 'dynamic_step_forms' %>

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -75,8 +75,8 @@
   <div id="dropdownBackground" class="dropdown-bg"></div>
 </div>
 
-  <%= javascript_include_tag 'add_form' %>
-  <%= javascript_include_tag 'ingredient_dropdown' %>
-  <%= javascript_include_tag 'menu_validation' %>
-  <%= javascript_include_tag 'image_preview' %>
-  <%= javascript_include_tag 'dynamic_step_forms' %>
+<%= javascript_include_tag 'add_form' %>
+<%= javascript_include_tag 'ingredient_dropdown' %>
+<%= javascript_include_tag 'menu_validation' %>
+<%= javascript_include_tag 'image_preview' %>
+<%= javascript_include_tag 'dynamic_step_forms' %>


### PR DESCRIPTION
目的：
既存の献立の再編集時に変更が正確に反映されるよう設定することが目的です

内容：
・既存献立の編集機能を設定
・既存献立の編集時の確認画面に工程が正しく表示されるよう修正

既存献立の編集時の確認画面 ：
<img width="1440" alt="スクリーンショット 2024-02-13 8 39 32" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/97875d2e-ef2d-4a76-a13a-8681245e2681">
<img width="1440" alt="スクリーンショット 2024-02-13 8 39 38" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/29dc630f-7450-4eef-8869-eb5c6082f8f9">