### PR TITLE
献立登録時の動的バリデーション機能を実装

### DIFF
--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -113,57 +113,59 @@
   }
 
   .steps-form-input {
-    .step-form-field {
-      display: flex; // 横並びにする
-      align-items: flex-start;
-      align-items: center;
+    .step-form-container{
+      .step-form-field {
+        display: flex; // 横並びにする
+        align-items: flex-start;
+        align-items: center;
 
-      .step-delete-button {
-        margin-right: 10px;
-      }
-
-      a {
-        text-decoration: none;
-      }
-
-      .step-field-wrapper{
-        width: 100%;
-        display: flex;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-
-        .step-form-number {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          border-right: 1px solid #ccc;
-          padding: 0.5em;
+        .step-delete-button {
+          margin-right: 10px;
         }
 
-        .step-fields {
-          display: block; // デフォルトでブロック要素なので、必要に応じて明示的に設定
-          width: 100%; // 幅を100%にする
+        a {
+          text-decoration: none;
+        }
 
-          .step-category-dropdown,
-          .step-description {
-            width: 100%;
-            margin-top: 0;
-            margin-bottom: 0;
-            font-size: 16px;
+        .step-field-wrapper{
+          width: 100%;
+          display: flex;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+
+          .step-form-number {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-right: 1px solid #ccc;
+            padding: 0.5em;
           }
 
-          .select-dropdown,
-          .text-field {
-            width: 100%;
-            border: none;
-            border-bottom: 1px solid #ccc; // 下線を追加
-            padding:5px;
-          }
+          .step-fields {
+            display: block; // デフォルトでブロック要素なので、必要に応じて明示的に設定
+            width: 100%; // 幅を100%にする
 
-          .step-description {
+            .step-category-dropdown,
+            .step-description {
+              width: 100%;
+              margin-top: 0;
+              margin-bottom: 0;
+              font-size: 16px;
+            }
+
+            .select-dropdown,
             .text-field {
-              width: calc(100% - 10px);
+              width: 100%;
               border: none;
+              border-bottom: 1px solid #ccc; // 下線を追加
+              padding:5px;
+            }
+
+            .step-description {
+              .text-field {
+                width: calc(100% - 10px);
+                border: none;
+              }
             }
           }
         }

--- a/app/javascript/add_form.js
+++ b/app/javascript/add_form.js
@@ -17,7 +17,7 @@ var INGREDIENT_DECIMAL_BASE = 10;
 // フォームが少なくとも1つ存在することを示す最小フォームカウント
 var INGREDIENT_MIN_FORM_COUNT = 1;
 // 新規登録フォームのデフォルト数
-var INGREDIENT_DEFAULT_NEW_FORM_COUNT = 5;
+var INGREDIENT_DEFAULT_NEW_FORM_COUNT = 3;
 // 食材未登録時に生成するフォームの数
 var INGREDIENT_NO_INGREDIENT_FORM_COUNT = 0;
 // 2桁表示が必要になる数値のしきい値
@@ -77,6 +77,8 @@ function createNewForm() {
 
   if (ingredientFormCountView < ingredientMaxFormCountView) {
     let newForm = `
+    <div class="ingredient-form-container">
+      <div id="ingredient-error[${newFormCount_back}]" class="ingredient-error-message"></div>
       <div class="custom-ingredient-fields">
         <div class="form-delete-button">
           <a href="#" class="form-count-down" data-action="decrement",  id="form-count-down[${newFormCount_back}]">❌</a>
@@ -87,7 +89,8 @@ function createNewForm() {
         <input type="number" id="ingredient_quantity[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][quantity]" autocomplete="quantity" placeholder="数量" maxlength="4" step="0.1" class="ingredient-quantity">
         <select id="menu_ingredients_unit[${newFormCount_back}]" name="menu[ingredients][${newFormCount_back}][unit_id]" class="ingredient-unit" tabindex="-1">
         </select>
-      </div>`;
+      </div>
+    </div>`;
 
     ingredient_form.insertAdjacentHTML("beforeend", newForm);
     ingredientFormCountView++;

--- a/app/javascript/dynamic_step_forms.js
+++ b/app/javascript/dynamic_step_forms.js
@@ -13,7 +13,7 @@ var FORM_INDEX_OFFSET = 1;
 // 二桁表示が必要になる数値のしきい値（9を超えたら二桁が必要）
 var TWO_DIGIT_DISPLAY_THRESHOLD = 10;
 // デフォルトで表示されるフォームの最大数
-var DEFAULT_MAX_FORM_COUNT = 5;
+var DEFAULT_MAX_FORM_COUNT = 3;
 // 工程未登録時に生成するフォームの数
 var INGREDIENT_NO_FORM_STEPS_COUNT = 0;
 // フォームが少なくとも1つ存在することを示す最小フォームカウント
@@ -123,30 +123,33 @@ function createNewStepForm() {
   // 新しいフォームのHTML構造
   // 新しいフォームのHTMLを生成
   let newFormHtml = `
-    <div class="step-form-field">
+    <div class="step-form-container">
+      <div id="step-error[${stepFormCount_Back}]" class="step-error-message"></div>
+      <div class="step-form-field">
 
-      <div class="step-delete-button">
-        <a href="#" class="step-form-count-down" data-action="decrement",  id="step-form-count-down[${stepFormCount_Back}]">❌</a>
-      </div>
-
-      <div class="step-field-wrapper">
-        <div class="step-form-number">
-          ${paddedNewFormCount}
+        <div class="step-delete-button">
+          <a href="#" class="step-form-count-down" data-action="decrement",  id="step-form-count-down[${stepFormCount_Back}]">❌</a>
         </div>
 
-        <div class="step-fields">
-          <div class="step-category-dropdown">
-            <select id="recipe_step_category_id[${stepFormCount_Back}]" name="menu[recipe_steps][${stepFormCount_Back}][recipe_step_category_id]" class="select-dropdown">
-              <option value="">工程ジャンルを選択してください。</option>
-              <option value="1">野菜の下準備（切る/剥くなど）</option>
-              <option value="2">肉の下準備（切る/解凍など）</option>
-              <option value="3">その他の下準備（切る/解凍など）</option>
-              <option value="4">調理（焼く/煮る/蒸すなど）</option>
-              <option value="5">その他（混ぜる/盛り付けなど）</option>
-            </select>
+        <div class="step-field-wrapper">
+          <div class="step-form-number">
+            ${paddedNewFormCount}
           </div>
-          <div class="step-description">
-            <textarea id="recipe_steps_description[${stepFormCount_Back}]" name="menu[recipe_steps][${stepFormCount_Back}][description]" maxlength="60" class="text-field" placeholder="メモ（最大60文字）" rows="2"></textarea>
+
+          <div class="step-fields">
+            <div class="step-category-dropdown">
+              <select id="recipe_step_category_id[${stepFormCount_Back}]" name="menu[recipe_steps][${stepFormCount_Back}][recipe_step_category_id]" class="select-dropdown">
+                <option value="">工程ジャンルを選択してください。</option>
+                <option value="1">野菜の下準備（切る/剥くなど）</option>
+                <option value="2">肉の下準備（切る/解凍など）</option>
+                <option value="3">その他の下準備（切る/解凍など）</option>
+                <option value="4">調理（焼く/煮る/蒸すなど）</option>
+                <option value="5">その他（混ぜる/盛り付けなど）</option>
+              </select>
+            </div>
+            <div class="step-description">
+              <textarea id="recipe_steps_description[${stepFormCount_Back}]" name="menu[recipe_steps][${stepFormCount_Back}][description]" class="text-field" placeholder="メモ（最大60文字）" rows="2"></textarea>
+            </div>
           </div>
         </div>
       </div>

--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -38,10 +38,8 @@ document.addEventListener('submit', function(event) {
       hasError = true;
     }
   });
-  console.log(hasError);
 
   if (hasError) {
-    console.log("きました");
     event.preventDefault();
   }
 });

--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -1,67 +1,182 @@
+
+setTimeout(initializeRealtimeValidation, 500);
+
 document.addEventListener('submit', function(event) {
   // イベントが発生したフォーム内の 'next_step_button' を探し、ない場合には処理を行わない。
   let nextStepButton = event.target.querySelector('#next_step_button');
   if (!nextStepButton) return;
 
-  let minForm = 0;
-  let maxForm = 14;
+  let hasError = false; // エラーを追跡するためのフラグ
   let menu_name = document.getElementById("menu_name");
   let menu_contents = document.getElementById("menu_contents");
-  // let contents = document.getElementById("contents");
   let errorMessage_name = document.getElementById("menu-error_name");
   let errorMessage_menu_contents = document.getElementById("menu-error-menu-contents");
-  let errorMessage_contents = document.getElementById("menu-error-contents");
   let inputName = document.querySelector(".name-form-field input");
   let inputContent = document.querySelector(".menu-contents-field input");
-  let inputText = document.querySelector("textarea");
 
-  // menuモデルのバリデーション
-  validateAndHighlightInput(menu_name, errorMessage_name, inputName, event)
-  validateAndHighlightInput(menu_contents, errorMessage_menu_contents, inputContent, event)
-  // validateAndHighlightInput(contents, errorMessage_contents, inputText, event)
 
-  // ingredientモデルのバリデーション
-  for (let i = minForm; i < maxForm; i++) {
-    const EXCEPTIONAL_UNIT_IDS = ["17"]; // 17は「少々」という単位のunit_idです。
-    const ingredientNameInput = document.getElementById("ingredient_name[" + i + "]");
+  if (!validateAndHighlightInput(menu_name, errorMessage_name, inputName, event)) {
+    hasError = true;
+  }
 
-    if (!ingredientNameInput || ingredientNameInput.value.trim() === "") continue;
+  if (!validateAndHighlightInput(menu_contents, errorMessage_menu_contents, inputContent, event)) {
+    hasError = true;
+  }
 
-    const ingredientUnitInput = document.getElementById("menu_ingredients_unit[" + i + "]");
-    const selectedUnitId = ingredientUnitInput.value;
+  if (!ValidateStepFormFields(event)) {
+    hasError = true;
+  }
 
-    // EXCEPTIONAL_UNIT_IDSに設定」されているIDはバリデーションを行わない
-    if (EXCEPTIONAL_UNIT_IDS.includes(selectedUnitId)) continue;
+  // ingredientフォームのバリデーション
+  const ingredientFormContainers = document.querySelectorAll('.ingredient-form-container');
+  ingredientFormContainers.forEach((ingredientFormContainer, index) => {
+    const nameInput = ingredientFormContainer.querySelector('.ingredient-name');
+    const quantityInput = ingredientFormContainer.querySelector('.ingredient-quantity');
+    const errorDiv = ingredientFormContainer.querySelector('.ingredient-error-message');
+    if (nameInput.value.trim() == "") return;
+    if (!validateIngredientQuantity(quantityInput, errorDiv)) {
+      hasError = true;
+    }
+  });
+  console.log(hasError);
 
-    validateInput("ingredient_quantity[" + i + "]");
+  if (hasError) {
+    console.log("きました");
+    event.preventDefault();
   }
 });
 
+function initializeRealtimeValidation() {
+  const menuNameInput = document.getElementById("menu_name");
+  const menuContentsInput = document.getElementById("menu_contents");
+  const stepFormContainers = document.querySelectorAll('.step-form-container');
+  let errorMessage_name = document.getElementById("menu-error_name");
+  let errorMessage_menu_contents = document.getElementById("menu-error-menu-contents");
+  let inputName = document.querySelector(".name-form-field input");
+  let inputContent = document.querySelector(".menu-contents-field input");
 
-function validateAndHighlightInput(element ,sub_errorMessage, inputElement, event) {
-  let menu_main_errorMessage = document.getElementById("main-menu-error");
+  // メニュー名のリアルタイムバリデーション
+  menuNameInput.addEventListener('input', function() {
+    setupDelayedValidation(menu_name, () => validateAndHighlightInput(menu_name, errorMessage_name, inputName));
+  });
 
-  if (element.value === "" ) {
-    event.preventDefault();
-    menu_main_errorMessage.textContent = "⚠️未入力があります。";
-    sub_errorMessage.textContent = "⚠️必須";
+  // メニュー内容のリアルタイムバリデーション
+  menuContentsInput.addEventListener('input', function() {
+    setupDelayedValidation(menu_contents, () => validateAndHighlightInput(menu_contents, errorMessage_menu_contents, inputContent));
+  });
+
+  // 各ステップのリアルタイムバリデーション
+  stepFormContainers.forEach((stepFormContainer) => {
+    const dropdown = stepFormContainer.querySelector('.step-category-dropdown select');
+    const textarea = stepFormContainer.querySelector('.step-description textarea');
+
+    // ドロップダウンの変更をリアルタイムでバリデーション（500ms遅延）
+    setupDelayedValidation(dropdown, () => ValidateStepFormFields(stepFormContainer));
+
+    // テキストエリアの入力をリアルタイムでバリデーション（500ms遅延）
+    setupDelayedValidation(textarea, () => ValidateStepFormFields(stepFormContainer));
+  });
+
+  let ingredientFormContainers = document.querySelectorAll('.ingredient-form-container');
+
+  ingredientFormContainers.forEach((ingredientFormContainer) => {
+    const ingredientQuantityInput = ingredientFormContainer.querySelector('.ingredient-quantity');
+    const errorDiv = ingredientFormContainer.querySelector('.ingredient-error-message');
+    setupDelayedValidation(ingredientQuantityInput, () => validateIngredientQuantity(ingredientQuantityInput, errorDiv));
+  });
+}
+
+function setupDelayedValidation(inputElement, validationFunction) {
+  let validationTimeout;
+  inputElement.addEventListener('input', function() {
+    clearTimeout(validationTimeout);
+    validationTimeout = setTimeout(validationFunction, 500);
+  });
+  inputElement.addEventListener('change', function() {
+    clearTimeout(validationTimeout);
+    validationTimeout = setTimeout(validationFunction, 500);
+  });
+}
+
+
+function validateAndHighlightInput(element, sub_errorMessage, inputElement) {
+  // 入力値が空、または20文字を超えている場合にエラーメッセージを表示
+  if (element.value.trim() === "" || element.value.trim().length > 20) {
+    sub_errorMessage.textContent = "⚠️必須：20文字以内で入力してください。";
     inputElement.style.backgroundColor = "rgb(255, 184, 184)";
+    return false;
   } else {
-    menu_main_errorMessage.textContent = "";
+    // 条件を満たしている場合はエラーメッセージと背景色をクリア
     sub_errorMessage.textContent = "";
     inputElement.style.backgroundColor = "";
+    return true;
   }
 }
 
-function validateInput(inputId) {
-  let errorMessage_ingredient = document.getElementById('ingredients-error');
-  let input = document.getElementById(inputId);
-  if (input && input.value === "" ) {
-    event.preventDefault();
-    input.style.backgroundColor = "rgb(255, 184, 184)";
-    errorMessage_ingredient.textContent = "⚠️未入力があります。";
+function ValidateStepFormFields(event) {
+  const stepFormContainers = document.querySelectorAll('.step-form-container');
+  let hasError = false;
+
+  stepFormContainers.forEach((stepFormContainer) => {
+    const dropdown = stepFormContainer.querySelector('.step-category-dropdown select');
+    const textarea = stepFormContainer.querySelector('.step-description textarea');
+    const errorDiv = stepFormContainer.querySelector('.step-error-message');
+
+    // エラーメッセージの初期化
+    errorDiv.textContent = '';
+    errorDiv.style.color = 'red';
+    errorDiv.style.backgroundColor = "";
+
+    // ドロップダウンまたはテキストエリアのいずれかが入力されているかをチェック
+    const isDropdownEntered = dropdown && dropdown.value;
+    const isTextareaEntered = textarea && textarea.value.trim();
+
+    // 両方が未入力の場合はバリデーションをスキップ
+    if (!isDropdownEntered && !isTextareaEntered) {
+      dropdown.style.backgroundColor = "";
+      textarea.style.backgroundColor = "";
+      return;
+    }
+
+    // ドロップダウンの選択を検証
+    if (!isDropdownEntered) {
+      dropdown.style.backgroundColor = "rgb(255, 184, 184)";
+      errorDiv.textContent += "⚠️必須：工程ジャンルを選択してください。";
+      hasError = true;
+    }else {
+      dropdown.style.backgroundColor = "";
+    }
+
+    // テキストエリアの入力を検証
+    if (textarea && (!textarea.value.trim() || textarea.value.trim().length > 60)) {
+      textarea.style.backgroundColor = "rgb(255, 184, 184)";
+      errorDiv.textContent = "⚠️必須：60文字以内で入力してください。";
+      hasError = true;
+    }else {
+      textarea.style.backgroundColor = "";
+    }
+  });
+
+  return !hasError;
+}
+
+function validateIngredientQuantity(quantityInput, errorDiv) {
+  const quantityValue = quantityInput.value.trim();
+
+  // 数量が半角数字ではない、または空の場合にエラーメッセージを表示
+  if (!quantityValue || !isHalfWidthNumber(quantityValue)) {
+    errorDiv.textContent = "⚠️必須：半角数字で数量の設定をしてください。";
+    quantityInput.style.backgroundColor = "rgb(255, 184, 184)";
+    errorDiv.style.color = "red";
+    return false;
   } else {
-    input.style.backgroundColor = "";
+    errorDiv.textContent = "";
+    quantityInput.style.backgroundColor = "";
+    errorDiv.style.color = "";
   }
 }
 
+// 半角数字のみかどうかをチェックするヘルパー関数
+function isHalfWidthNumber(value) {
+  return /^[0-9]+$/.test(value);
+}

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -13,8 +13,8 @@ class Menu < ApplicationRecord
   # 全てのバリデーションエラーメッセージを統一
   common_error_message = '登録中に予期せぬエラーが発生しました。'
 
-  validates :menu_name, presence: { message: common_error_message }, length: { maximum: 15, message: common_error_message }
-  validates :menu_contents, presence: { message: common_error_message }, length: { maximum: 60, message: common_error_message }
+  validates :menu_name, presence: { message: common_error_message }, length: { maximum: 20, message: common_error_message }
+  validates :menu_contents, presence: { message: common_error_message }, length: { maximum: 20, message: common_error_message }
   before_validation :set_default_image
 
   validate :validate_ingredients

--- a/app/views/menus/_form_fields.html.erb
+++ b/app/views/menus/_form_fields.html.erb
@@ -5,7 +5,7 @@
 
 <div id="menu-error-menu-contents" class="menu-error"></div>
 <div class="menu-contents-field">
-  <%= f.text_field :menu_contents, autofocus: false, id: "menu_contents", autocomplete: "menu_contents", placeholder: "献立の説明(最大60字)" %>
+  <%= f.text_field :menu_contents, autofocus: false, id: "menu_contents", autocomplete: "menu_contents", placeholder: "献立の説明(最大20字)" %>
 </div>
 
 <div class="image-field">

--- a/app/views/menus/edit.html.erb
+++ b/app/views/menus/edit.html.erb
@@ -9,8 +9,6 @@
       <p>１.献立情報入力</p>
     </div>
 
-    <div id="main-menu-error" class="menu-error-message"></div>
-
     <div class="menu-form-input">
       <%= form_with model: @menu, url: confirm_user_menu_path(current_user), method: :post, id: "menu_form" do |f| %>
         <%= f.hidden_field :menu_id, value: @menu.id %>

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -9,8 +9,6 @@
       <p>１.献立情報の設定</p>
     </div>
 
-    <div id="main-menu-error" class="menu-error-message"></div>
-
     <div class="menu-form-input">
       <%= form_with model: @menu, url: confirm_user_menu_path(current_user.id), method: :post, id: "menu_form" do |f| %>
         <%= render 'form_fields', f: f %>
@@ -42,13 +40,13 @@
           <p>３.必要食材の設定</p>
         </div>
 
-        <div id="ingredients-error" class="ingredients-error-message"></div>
         <div id ="ingredients-date", data-ingredients="<%= @menu.ingredients.to_json %>"></div>
 
         <div class="ingredient-form-input" id="ingredient-form-input">
           <div class="ingredient-form-field">
             <div id="ingredient-form-add-container">
               <%= f.fields_for :ingredients do |ingredient_form| %>
+                <div id="ingredient-error" class="ingredient-error-message"></div>
                 <div id="ingredient_form"></div>
                 <%= render 'ingredient_selector', materials_by_category: @materials_by_category, menu: @menu %>
               <% end %>


### PR DESCRIPTION
目的：
ユーザが献立をスムーズに登録できるよう、フォーム入力時の即時フィードバックを提供すること

内容：
・入力フォームに動的なバリデーションチェックを追加
・エラー発生時にユーザに対して直接的な視覚的フィードバックを提供
・フォーム入力のガイドラインを明確化
・正しい入力がされた際にはフィードバックをリセット

<img width="1440" alt="スクリーンショット 2024-02-13 23 40 36" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/acf4cdb3-8624-486e-b8bb-3f25ad1f1c78">
<img width="1432" alt="スクリーンショット 2024-02-13 23 41 48" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/ebabf378-fe1f-4768-8daa-baeb9885f1bf">
<img width="1016" alt="スクリーンショット 2024-02-13 23 46 58" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/8ba1ddca-12e6-4f52-b2de-277596000e2c">
