### PR TITLE
献立説明の自由入力化と未登録時のView対応を実装

### DIFF
--- a/app/assets/stylesheets/shared/_menuForm.scss
+++ b/app/assets/stylesheets/shared/_menuForm.scss
@@ -27,6 +27,11 @@
   padding-top: 10px;
   text-decoration: underline;
   text-align:  center;
+
+  .required-text {
+    color: red;
+    font-size: 15px;
+  }
 }
 
 @mixin default-button-style{

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -401,6 +401,11 @@ class MenusController < ApplicationController
   end
 
   def check_menu_selection
+    # current_userに紐づくカートがない場合、新しいカートを作成
+    if current_user.cart.nil?
+      current_user.create_cart
+    end
+
     if current_user_cart.cart_items.exists?(menu_id: params[:menu_id])
       flash[:error] = "この献立は現在選択されているため、編集（削除）はできません。"
       redirect_to user_menu_path(menu_id: params[:menu_id])

--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -14,12 +14,11 @@ document.addEventListener('submit', function(event) {
   let inputName = document.querySelector(".name-form-field input");
   let inputContent = document.querySelector(".menu-contents-field input");
 
-
   if (!validateAndHighlightInput(menu_name, errorMessage_name, inputName, event)) {
     hasError = true;
   }
 
-  if (!validateAndHighlightInput(menu_contents, errorMessage_menu_contents, inputContent, event)) {
+  if (!validateInputLength(menu_contents, errorMessage_menu_contents, inputContent, event)) {
     hasError = true;
   }
 
@@ -60,7 +59,7 @@ function initializeRealtimeValidation() {
 
   // メニュー内容のリアルタイムバリデーション
   menuContentsInput.addEventListener('input', function() {
-    setupDelayedValidation(menu_contents, () => validateAndHighlightInput(menu_contents, errorMessage_menu_contents, inputContent));
+    setupDelayedValidation(menu_contents, () => validateInputLength(menu_contents, errorMessage_menu_contents, inputContent));
   });
 
   // 各ステップのリアルタイムバリデーション
@@ -96,11 +95,24 @@ function setupDelayedValidation(inputElement, validationFunction) {
   });
 }
 
-
 function validateAndHighlightInput(element, sub_errorMessage, inputElement) {
   // 入力値が空、または20文字を超えている場合にエラーメッセージを表示
   if (element.value.trim() === "" || element.value.trim().length > 20) {
     sub_errorMessage.textContent = "⚠️必須：20文字以内で入力してください。";
+    inputElement.style.backgroundColor = "rgb(255, 184, 184)";
+    return false;
+  } else {
+    // 条件を満たしている場合はエラーメッセージと背景色をクリア
+    sub_errorMessage.textContent = "";
+    inputElement.style.backgroundColor = "";
+    return true;
+  }
+}
+
+function validateInputLength(element, sub_errorMessage, inputElement) {
+  // 入力値が60文字を超えている場合にエラーメッセージを表示
+  if (element.value.trim().length > 20) {
+    sub_errorMessage.textContent = "⚠️20文字以内で入力してください。";
     inputElement.style.backgroundColor = "rgb(255, 184, 184)";
     return false;
   } else {
@@ -171,6 +183,7 @@ function validateIngredientQuantity(quantityInput, errorDiv) {
     errorDiv.textContent = "";
     quantityInput.style.backgroundColor = "";
     errorDiv.style.color = "";
+    return true;
   }
 }
 

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -14,7 +14,7 @@ class Menu < ApplicationRecord
   common_error_message = '登録中に予期せぬエラーが発生しました。'
 
   validates :menu_name, presence: { message: common_error_message }, length: { maximum: 20, message: common_error_message }
-  validates :menu_contents, presence: { message: common_error_message }, length: { maximum: 20, message: common_error_message }
+  validates :menu_contents, length: { maximum: 20, message: common_error_message }, allow_blank: true
   before_validation :set_default_image
 
   validate :validate_ingredients

--- a/app/views/menus/_form_fields.html.erb
+++ b/app/views/menus/_form_fields.html.erb
@@ -3,9 +3,18 @@
   <%= f.text_field :menu_name, autofocus: false, id: "menu_name", autocomplete: "menu_name", placeholder: "献立名(最大20字)" %>
 </div>
 
+
+<div class ="contents-title">
+  <p>２.献立説明を設定</p>
+</div>
+
 <div id="menu-error-menu-contents" class="menu-error"></div>
 <div class="menu-contents-field">
   <%= f.text_field :menu_contents, autofocus: false, id: "menu_contents", autocomplete: "menu_contents", placeholder: "献立の説明(最大20字)" %>
+</div>
+
+<div class ="contents-title">
+  <p>３.献立画像を設定</p>
 </div>
 
 <div class="image-field">

--- a/app/views/menus/_menu_confirm_details.html.erb
+++ b/app/views/menus/_menu_confirm_details.html.erb
@@ -11,13 +11,15 @@
     <%= f.hidden_field :menu_name, value: menu.menu_name %>
   </div>
 
-  <div class ="contents-title">
-    <p>　献立の説明　</p>
-  </div>
-  <div class ="menu-contents">
-    <%= menu.menu_contents %>
-    <%= f.hidden_field :menu_contents, value: menu.menu_contents %>
-  </div>
+  <% if menu.menu_contents.present? %>
+    <div class ="contents-title">
+      <p>　献立の説明　</p>
+    </div>
+    <div class ="menu-contents">
+      <%= menu.menu_contents %>
+      <%= f.hidden_field :menu_contents, value: menu.menu_contents %>
+    </div>
+  <% end %>
 
   <div class ="contents-title">
     <p>　献立画像　</p>

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -6,7 +6,7 @@
     </div>
 
     <div class ="contents-title">
-      <p>１.献立情報の設定</p>
+      <p>１.献立名の設定<span class="required-text">（※必須）</span></p>
     </div>
 
     <div class="menu-form-input">
@@ -21,7 +21,7 @@
         <% end %>
 
         <div class ="contents-title">
-          <p>２.作り方の設定</p>
+          <p>４.作り方の設定<span class="required-text">（※必須）</span></p>
         </div>
 
         <div id ="steps-date", data-steps="<%= @menu.recipe_steps.to_json %>"></div>
@@ -37,7 +37,7 @@
         </div>
 
         <div class ="contents-title">
-          <p>３.必要食材の設定</p>
+          <p>５.必要食材の設定<span class="required-text">（※必須）</span></p>
         </div>
 
         <div id ="ingredients-date", data-ingredients="<%= @menu.ingredients.to_json %>"></div>

--- a/app/views/shared/_menu_details.html.erb
+++ b/app/views/shared/_menu_details.html.erb
@@ -12,12 +12,14 @@
     <%= menu.menu_name %>
   </div>
 
-  <div class="show-contents-title">
-    <p>　献立の説明　</p>
-  </div>
-  <div class ="menu-contents">
-    <%= menu.menu_contents %>
-  </div>
+  <% if menu.menu_contents.present? %>
+    <div class="show-contents-title">
+      <p>　献立の説明　</p>
+    </div>
+    <div class ="menu-contents">
+      <%= menu.menu_contents %>
+    </div>
+  <% end %>
 
   <div class="show-contents-title">
     <p>　献立画像　</p>

--- a/db/migrate/20230906091255_create_menus.rb
+++ b/db/migrate/20230906091255_create_menus.rb
@@ -2,7 +2,7 @@ class CreateMenus < ActiveRecord::Migration[7.0]
   def change
     create_table :menus do |t|
       t.string :menu_name,               null: false, default: ""
-      t.text :menu_contents,             null: false, default: ""
+      t.text :menu_contents,             null: true
       t.text :image_meta_data,           null: false, default: ""
       t.string :image,                   null: false, default: ""
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,7 +120,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_09_050421) do
 
   create_table "menus", force: :cascade do |t|
     t.string "menu_name", default: "", null: false
-    t.text "menu_contents", default: "", null: false
+    t.text "menu_contents"
     t.text "image_meta_data", default: "", null: false
     t.string "image", default: "", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
目的：
献立の説明欄を自由入力可能にし、入力内容に対するバリデーションを柔軟に対応させることで、ユーザーがより詳細な献立情報を登録できるようにするという目的です。

内容：
・献立の説明欄を自由入力に変更
・献立の説明が未登録の場合に対応するViewのロジックを追加
・献立の説明に対する動的バリデーションを、20文字以内の入力のみに適用するように調整
・未入力でも献立の説明が受け入れられるよう、バリデーションの条件を更新

<img width="1440" alt="スクリーンショット 2024-02-14 1 25 07" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/d625b042-1a0f-4f33-8ead-51caa941f4e3">
<img width="1440" alt="スクリーンショット 2024-02-14 1 25 14" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/40f6dd41-b826-4157-8850-40c292493cb5">

<img width="1440" alt="スクリーンショット 2024-02-14 1 33 10" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/8fdb4058-2b9b-45db-b4c3-52202e93f6df">
<img width="1440" alt="スクリーンショット 2024-02-14 1 33 15" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/173054db-c0f7-4420-9e65-5c850979da38">