### PR TITLE
献立詳細画面に作り方工程を表示するview設定を追加

### DIFF
--- a/app/assets/stylesheets/menu_details.scss
+++ b/app/assets/stylesheets/menu_details.scss
@@ -5,4 +5,48 @@
   .show-contents-title{
     @include contents-title;
   }
+
+  .recipe-step-container{
+    width: 70%;
+    @media screen and (max-width: 500px) {
+      width: 100%;
+    }
+    .recipe-step-contents {
+      width: 100%;
+      margin-bottom: 20px;
+      text-align: left;
+      border: 1px solid #ccc;
+      padding: 10px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      @media screen and (max-width: 500px) {
+        padding-left: 0;
+        padding-right: 0;
+        text-align: center;
+      }
+
+      .step-header {
+        display: flex;
+        align-items: center;
+        justify-content: start;
+
+        .step-order,
+        .step-category-name {
+          font-size: 18px;
+          margin-right: 10px;
+          @media screen and (max-width: 500px) {
+            margin-left: 10px;
+          }
+        }
+
+        .step-description {
+          word-wrap: break-word;
+        }
+
+        // 必要に応じて各項目のスタイルを追加
+        .step-order {
+          font-weight: bold;
+        }
+      }
+    }
+  }
 }

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -177,6 +177,9 @@ class MenusController < ApplicationController
 
     # scale_ingredientsメソッドを呼び出して、quantityを更新
     @scaled_ingredients = scale_ingredients(aggregated_ingredients, @serving_size)
+
+    # 作り方の工程データを取得
+    @recipe_steps = RecipeStep.where(menu_id: @menu.id)
   end
 
 

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -1,7 +1,7 @@
 
 <div class="menu-show-container" id="menu-show-container">
   <div class="menu-detail-container">
-    <%= render partial: 'shared/menu_details', locals: { menu: @menu } %>
+    <%= render 'shared/menu_details', menu: @menu, recipe_steps: @recipe_steps %>
 
     <div class="ingredient-show-container">
       <div class ="show-contents-title">

--- a/app/views/shared/_menu_details.html.erb
+++ b/app/views/shared/_menu_details.html.erb
@@ -28,4 +28,28 @@
   <div class ="menu-contents">
     <%= image_tag(rails_blob_path(menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
   </div>
+
+  <div class="show-contents-title">
+    <p>　作り方　</p>
+  </div>
+
+  <% if recipe_steps.present? %>
+    <% recipe_steps.each_with_index do |step, index| %>
+      <div class ="recipe-step-container">
+        <div class ="recipe-step-contents">
+          <div class="step-header">
+            <div class="step-order">
+              <p><%= index + 1 %></p>
+            </div>
+            <div class="step-category-name">
+              <p><%= step.recipe_step_category.name %></p>
+            </div>
+          </div>
+          <div class="step-description">
+            <p><%= step.description %></p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
 </div>


### PR DESCRIPTION

目的：
献立詳細画面にレシピの作り方工程を表示し、ユーザーが献立の内容をより詳細に理解できるようにすることです。

内容：
・献立詳細画面のviewにレシピの作り方工程データを表示する機能を追加
・recipe_steps データを menu_details パーシャルに渡す処理を実装
・表示レイアウトを調整して、工程情報が視覚的にわかりやすくなるように設定

<img width="1440" alt="スクリーンショット 2024-02-14 1 59 11" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/8d9d3891-3adc-4bdc-b617-ea3183805c25">
<img width="1440" alt="スクリーンショット 2024-02-14 1 59 20" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/5898d4c6-4913-4380-a22f-7d62f2282a97">
