### PR TITLE
CookingFlowとStepモデル及びリレーションを追加・適用

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -2,4 +2,5 @@ class Cart < ApplicationRecord
   belongs_to :user
   has_many :cart_items, dependent: :destroy
   has_one :shopping_list, dependent: :destroy
+  has_one :cooking_flow, dependent: :destroy
 end

--- a/app/models/cooking_flow.rb
+++ b/app/models/cooking_flow.rb
@@ -1,0 +1,4 @@
+class CookingFlow < ApplicationRecord
+  belongs_to :cart
+  has_many :cooking_steps, dependent: :destroy
+end

--- a/app/models/cooking_step.rb
+++ b/app/models/cooking_step.rb
@@ -1,0 +1,4 @@
+class CookingStep < ApplicationRecord
+  belongs_to :cooking_flow
+  belongs_to :recipe_step
+end

--- a/app/models/recipe_step.rb
+++ b/app/models/recipe_step.rb
@@ -1,6 +1,7 @@
 class RecipeStep < ApplicationRecord
   belongs_to :menu, optional: true
   belongs_to :recipe_step_category
+  has_many :cooking_steps
 
   # 全てのバリデーションエラーメッセージを統一
   common_error_message = '登録中に予期せぬエラーが発生しました。'

--- a/db/migrate/20240214051547_create_cooking_flows.rb
+++ b/db/migrate/20240214051547_create_cooking_flows.rb
@@ -1,0 +1,9 @@
+class CreateCookingFlows < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cooking_flows do |t|
+      t.references :cart, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240214051600_create_cooking_steps.rb
+++ b/db/migrate/20240214051600_create_cooking_steps.rb
@@ -1,0 +1,13 @@
+class CreateCookingSteps < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cooking_steps do |t|
+      t.references :cooking_flow,       null: false, foreign_key: true
+      t.references :recipe_step,        null: false, foreign_key: true
+      t.string :menu_name,              null: false, default: ""
+      t.integer :step_order
+      t.boolean :is_checked
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_09_050421) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_14_051600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -76,6 +76,25 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_09_050421) do
     t.datetime "updated_at", null: false
     t.index ["menu_id"], name: "index_completed_menus_on_menu_id"
     t.index ["user_id"], name: "index_completed_menus_on_user_id"
+  end
+
+  create_table "cooking_flows", force: :cascade do |t|
+    t.bigint "cart_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cart_id"], name: "index_cooking_flows_on_cart_id"
+  end
+
+  create_table "cooking_steps", force: :cascade do |t|
+    t.bigint "cooking_flow_id", null: false
+    t.bigint "recipe_step_id", null: false
+    t.string "menu_name", default: "", null: false
+    t.integer "step_order"
+    t.boolean "is_checked"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cooking_flow_id"], name: "index_cooking_steps_on_cooking_flow_id"
+    t.index ["recipe_step_id"], name: "index_cooking_steps_on_recipe_step_id"
   end
 
   create_table "ingredients", force: :cascade do |t|
@@ -215,6 +234,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_09_050421) do
   add_foreign_key "carts", "users"
   add_foreign_key "completed_menus", "menus"
   add_foreign_key "completed_menus", "users"
+  add_foreign_key "cooking_flows", "carts"
+  add_foreign_key "cooking_steps", "cooking_flows"
+  add_foreign_key "cooking_steps", "recipe_steps"
   add_foreign_key "recipe_steps", "menus"
   add_foreign_key "recipe_steps", "recipe_step_categories"
   add_foreign_key "shopping_list_items", "categories"

--- a/test/fixtures/cooking_flows.yml
+++ b/test/fixtures/cooking_flows.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  cart: one
+
+two:
+  cart: two

--- a/test/fixtures/cooking_steps.yml
+++ b/test/fixtures/cooking_steps.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  cooking_flow: one
+  recipe_step: one
+  step_order: 1
+  is_checked: false
+
+two:
+  cooking_flow: two
+  recipe_step: two
+  step_order: 1
+  is_checked: false

--- a/test/models/cooking_flow_test.rb
+++ b/test/models/cooking_flow_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CookingFlowTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/cooking_step_test.rb
+++ b/test/models/cooking_step_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CookingStepTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
献立の合算調理フローを管理する新機能実装のための基盤整備という目的です。

内容：
・CookingFlowモデルを新規作成
・CookingStepモデルを新規作成
・両モデル間のリレーションを設定
・必要なマイグレーションを実行