### PR TITLE
「まとめて調理」機能のためのコントローラーとボタン追加

### DIFF
--- a/app/controllers/cooking_flows_controller.rb
+++ b/app/controllers/cooking_flows_controller.rb
@@ -1,0 +1,5 @@
+class CookingFlowsController < ApplicationController
+  def create
+    binding.pry
+  end
+end

--- a/app/helpers/cooking_flows_helper.rb
+++ b/app/helpers/cooking_flows_helper.rb
@@ -1,0 +1,2 @@
+module CookingFlowsHelper
+end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -34,5 +34,6 @@
   <div class="button-set-container">
     <%= button_to "献立を選ぶ", sample_menus_path, class: "button-style bg-standard-menu", method: :get %>
     <%= button_to "買い物リスト", shopping_lists_path, class: "button-style bg-shopping-list", method: :post, id: "shopping-list" %>
+    <%= button_to "まとめて調理", cooking_flows_path, class: "button-style bg-standard-menu", method: :post %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :cooking_flows
+
   devise_for :users
   devise_scope :user do
     get 'users/confirmation/custom_confirm', to: 'custom_confirmations#custom_confirm', as: :custom_user_confirmation

--- a/test/controllers/cooking_flows_controller_test.rb
+++ b/test/controllers/cooking_flows_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CookingFlowsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
新機能「まとめて調理」をユーザーが利用できるようにするための前段階として、必要なコントローラーとビュー上のボタンを追加するという目的です。

内容：
・CookingFlowコントローラーを新規に設定
・CookingFlowのcreateアクションを定義（実際のロジックは未実装）
・ルーチングにcreateアクションへのパスを設定
・ホーム画面に「まとめて調理」機能へのPOSTリクエストを送るボタンを追加

<img width="1437" alt="スクリーンショット 2024-02-14 15 09 34" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/aa1acc07-a242-4ddc-a381-d707adfd5d6f">
<img width="1439" alt="スクリーンショット 2024-02-14 15 09 40" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/c080331e-2ac3-43e5-a264-6228a21ea766">