### PR TITLE
ドロップダウン表示を中央に固定し、背景スクロールを制御

### DIFF
--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -265,9 +265,10 @@
 
       .ingredient-select{
         display: none;
-        position: absolute;
-        left: 34%;
-        top: 30%;
+        position: fixed;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
         width: 30%;
         z-index: 10;
         background-color: #ffffff;

--- a/app/javascript/ingredient_dropdown.js
+++ b/app/javascript/ingredient_dropdown.js
@@ -161,7 +161,7 @@ function clearSearchResults(searchResultsTitle) {
   searchResultsTitle.style.display = "none";
 }
 
-// // 全てのingredients-listを表示する
+// 全てのingredients-listを表示する
 function openDropdown(ingredientList, dropdownBg, searchResultsTitle) {
   const categoryLists = document.querySelectorAll('.ingredient-category ul');
   categoryLists.forEach(list => {
@@ -171,6 +171,7 @@ function openDropdown(ingredientList, dropdownBg, searchResultsTitle) {
   dropdownBg.style.display = "block";
   ingredientList.style.display = "block";
   clearSearchResults(searchResultsTitle);
+  document.body.style.overflow = 'hidden';
 }
 
 // 全てのingredients-listの表示を非表示にする
@@ -179,6 +180,7 @@ function closeDropdown(ingredientList, searchInput, dropdownBg, searchResultsTit
   ingredientList.style.display = "none";
   searchInput.value = "";
   clearSearchResults(searchResultsTitle);
+  document.body.style.overflow = '';
 }
 
 // ingredient_unitに値が変更された時の処理


### PR DESCRIPTION
目的：
ドロップダウンの使いやすさを向上させるために、表示位置をユーザーの視界の中心に固定し、ドロップダウン操作中の背景スクロールを無効化するという目的です。

内容：
・ドロップダウンリストが画面中央に表示されるようCSSのスタイルを調整
・ドロップダウンリスト表示中は背景のスクロールを無効にするJavaScriptのロジックを実装
・ユーザーがドロップダウンリストを閉じた後に背景スクロールを再度有効にする処理を追加