### PR TITLE
モバイルでのドロップダウン位置を画面中央に修正

### DIFF
--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -277,11 +277,10 @@
         padding: 5px 20px;
         border-radius: 8px;
         @media screen and (max-width: 1000px) {
-          left: 25%;
+
           width: 45%;
         }
         @media screen and (max-width: 700px) {
-          left: 6%;
           width: 80%;
           padding: 0px 10px;
         }

--- a/app/javascript/dynamic_step_forms.js
+++ b/app/javascript/dynamic_step_forms.js
@@ -139,7 +139,7 @@ function createNewStepForm() {
           <div class="step-fields">
             <div class="step-category-dropdown">
               <select id="recipe_step_category_id[${stepFormCount_Back}]" name="menu[recipe_steps][${stepFormCount_Back}][recipe_step_category_id]" class="select-dropdown">
-                <option value="">工程ジャンルを選択してください。</option>
+                <option value="">工程ジャンルを選択</option>
                 <option value="1">野菜の下準備（切る/剥くなど）</option>
                 <option value="2">肉の下準備（切る/解凍など）</option>
                 <option value="3">その他の下準備（切る/解凍など）</option>


### PR DESCRIPTION
目的：
モバイル端末におけるユーザーの視認性と操作性を向上させるために、ドロップダウンリストが常に画面中央に表示されるようにするという目的です。

内容：
・モバイル表示時のドロップダウンリストの幅と位置を調整
・画面のサイズに応じたレスポンシブなスタイリングをCSSに実装
・画面中央にドロップダウンリストが表示されるようにCSSのtransformプロパティを適用