### PR TITLE
レシピ完了時の献立リセット機能を実装

### DIFF
--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -7,12 +7,12 @@ class CartItemsController < ApplicationController
     cart = current_user_cart || current_user.create_cart
 
     # 各モデルからのアイテム数の総計を取得
-    total_items_count = total_items_count(cart)
+    shopping_list_menus_count = ShoppingListMenu.where(shopping_list_id: cart.shopping_list&.id).count
     max_total_items = @settings.dig('limits', 'max_total_items')
 
     # 総数が20個を超えている場合の処理
-    if total_items_count >= max_total_items
-      flash[:error] = "献立の登録上限に達しました。"
+    if shopping_list_menus_count >= max_total_items
+      flash[:error] = "選択できる上限に達しました。"
       redirect_back(fallback_location: root_path) and return
     end
 
@@ -73,23 +73,5 @@ class CartItemsController < ApplicationController
     respond_to do |format|
       format.js { render partial: 'users/quantity', locals: { cart_item: cart_item } }
     end
-  end
-
-  private
-
-  # このメソッドは、ユーザーが関連するCompletedMenu、ShoppingListMenu、
-  # およびCartItemモデルからの総アイテム数を計算します。
-  def total_items_count(cart)
-    # ユーザーに関連するCompletedMenuモデルのアイテム数を計算
-    completed_menus_count = CompletedMenu.where(user_id: current_user.id, is_completed: false).count
-
-    # ユーザーのカートに関連するShoppingListMenuモデルのアイテム数を計算
-    shopping_list_menus_count = ShoppingListMenu.where(shopping_list_id: cart.shopping_list&.id).count
-
-    # カート内のCartItemモデルのアイテム数を計算
-    cart_items_count = cart.cart_items.count
-
-    # 3つのモデルからの総アイテム数を合計して返す
-    completed_menus_count + shopping_list_menus_count + cart_items_count
   end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -7,7 +7,6 @@ class Menu < ApplicationRecord
   has_many :cart_items, dependent: :destroy
   has_many :shopping_list_menus, dependent: :restrict_with_exception
   has_many :shopping_lists, through: :shopping_list_menus
-  has_many :completed_menus, dependent: :destroy
   has_many :recipe_steps, dependent: :destroy
 
   # 全てのバリデーションエラーメッセージを統一

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,7 @@ class User < ApplicationRecord
   has_many :menu_users, dependent: :destroy
   has_many :menus, through: :menu_users
   has_one :cart, dependent: :destroy
-  has_many :completed_menus, dependent: :destroy
   has_many :shopping_lists, dependent: :destroy
-  has_many :completed_menus, dependent: :destroy
 
   validates :name, presence: { message: "ユーザー名は必須です。" },
   length: { minimum: 2, too_short: "ユーザー名は最低%{count}文字必要です。", maximum: 15, too_long: "ユーザー名は最大%{count}文字までです。" },

--- a/app/views/cooking_flows/index.html.erb
+++ b/app/views/cooking_flows/index.html.erb
@@ -58,6 +58,8 @@
   <% end %>
 
   <div class="button-container">
+    <%= button_to '調理完了', complete_cooking_flow_path(@cooking_flow), method: :patch, class: 'back-button', form: { data: { turbo_confirm: "お疲れ様です！調理完了のため選択していた献立をリセットします。よろしいでしょうか？" } } %>
+
     <%= button_to "戻る", root_path, class: "back-button", method: :get %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,11 @@ Rails.application.routes.draw do
   post '/cart_items/:id/decrement', to: 'cart_items#decrement', as: 'cart_item_decrement'
   post '/shopping_lists/:id/toggle_check', to: 'shopping_lists#toggle_check', as: 'shopping_list_toggle_check'
 
-  resources :cooking_flows
+  resources :cooking_flows do
+    member do
+      patch :complete
+    end
+  end
 
   devise_for :users
   devise_scope :user do


### PR DESCRIPTION
目的：
調理完了後に選択していた献立を一括でリセットし、次回のレシピ選択をスムーズに行うという目的です。

内容：
・レシピページの献立リセット機能を実装
・カート及び関連データの削除処理を追加
・トランザクションを利用したデータ削除の安定性向上