### PR TITLE
調理完了ボタンのスタイルを設定

### DIFF
--- a/app/assets/stylesheets/cooking_flows.scss
+++ b/app/assets/stylesheets/cooking_flows.scss
@@ -155,6 +155,26 @@
     width: 100%;
     .back-button{
       @include button;
+      margin-top: 5px;
+      width: 50%;
+      @media screen and (max-width: 500px) {
+        width: 80%;
+      }
+    }
+
+    .complete-button{
+      @include button;
+      background-color: #1E9AF4;
+      color: white;
+      margin-bottom: 20px;
+      width: 50%;
+      @media screen and (max-width: 500px) {
+        width: 80%;
+      }
+
+      &:hover {
+        background-color: #b4e2ff;
+      }
     }
   }
 }

--- a/app/views/cooking_flows/index.html.erb
+++ b/app/views/cooking_flows/index.html.erb
@@ -58,7 +58,7 @@
   <% end %>
 
   <div class="button-container">
-    <%= button_to '調理完了', complete_cooking_flow_path(@cooking_flow), method: :patch, class: 'back-button', form: { data: { turbo_confirm: "お疲れ様です！調理完了のため選択していた献立をリセットします。よろしいでしょうか？" } } %>
+    <%= button_to '調理完了', complete_cooking_flow_path(@cooking_flow), method: :patch, class: 'complete-button', form: { data: { turbo_confirm: "お疲れ様です！調理完了のため選択していた献立をリセットします。よろしいでしょうか？" } } %>
 
     <%= button_to "戻る", root_path, class: "back-button", method: :get %>
   </div>


### PR DESCRIPTION
目的：
レシピページの利便性を向上させるために、調理完了を明示するボタンに視覚的なスタイルを追加するという目的です。

内容：
・調理完了ボタンにCSSスタイルを適用
・ユーザーが献立リセットを容易に行えるよう視認性を改善

<img width="1440" alt="スクリーンショット 2024-02-16 21 18 58" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/02360a0a-09e5-46ae-a7a8-880849099a3c">
<img width="1439" alt="スクリーンショット 2024-02-16 21 19 04" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/751817d8-54d6-472c-a21c-b1eda3046ea5">
<img width="464" alt="スクリーンショット 2024-02-16 21 19 16" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/fd1cbeb5-ecdd-40a5-82ec-bea741f928b9">
