### PR TITLE
ユーザー名のバリデーションを文字数制限2~15文字に絞り込み

### DIFF
--- a/app/javascript/form_validation.js
+++ b/app/javascript/form_validation.js
@@ -54,7 +54,7 @@ export function validateEmailInput(emailInput) {
     createErrorMessage(emailInput, "⚠️メールアドレスの形式が不正です");
     emailInput.style.backgroundColor = "rgb(255, 184, 184)";
   } else {
-    emailInput.style.backgroundColor = ""; // エラーがない場合は背景色をリセット
+    emailInput.style.backgroundColor = "";
   }
 }
 
@@ -62,16 +62,16 @@ export function validateNameInput(nameInput) {
   clearErrorMessages(nameInput);
 
   // ユーザー名の形式と文字数を確認する正規表現
-  const namePattern = /^[a-zA-Z0-9]{2,15}$/;
+  const nameLengthPattern = /^.{2,15}$/;
 
   if (!nameInput.value.trim()) {
     createErrorMessage(nameInput, "⚠️入力してください。");
     nameInput.style.backgroundColor = "rgb(255, 184, 184)";
-  } else if (!namePattern.test(nameInput.value)) {
-    createErrorMessage(nameInput, "⚠️2~15文字、英数字を含んでください。");
+  } else if (!nameLengthPattern.test(nameInput.value)) {
+    createErrorMessage(nameInput, "⚠️2~15文字で入力してください。");
     nameInput.style.backgroundColor = "rgb(255, 184, 184)";
   } else {
-    nameInput.style.backgroundColor = ""; // エラーがない場合は背景色をリセット
+    nameInput.style.backgroundColor = "";
   }
 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,7 @@ class User < ApplicationRecord
   has_many :shopping_lists, dependent: :destroy
 
   validates :name, presence: { message: "ユーザー名は必須です。" },
-  length: { minimum: 2, too_short: "ユーザー名は最低%{count}文字必要です。", maximum: 15, too_long: "ユーザー名は最大%{count}文字までです。" },
-  format: { with: /\A[a-zA-Z0-9]+\z/, message: 'ユーザー名は英数字のみが使用できます。' }, if: :user_info_change_or_new_record?
+  length: { minimum: 2, too_short: "ユーザー名は最低%{count}文字必要です。", maximum: 15, too_long: "ユーザー名は最大%{count}文字までです。" }, if: :user_info_change_or_new_record?
 
   # メールアドレスのバリデーション
   validates :email, presence: { message: "メールアドレスは必須です。" },

--- a/app/views/custom_registrations/edit_user_name.html.erb
+++ b/app/views/custom_registrations/edit_user_name.html.erb
@@ -5,7 +5,7 @@
   </div>
 
   <div class="registration-instructions">
-    <p>ユーザー名は2〜15文字、英数字で設定をしてください。</p>
+    <p>ユーザー名は2〜15文字で設定をしてください。</p>
   </div>
 
   <div class="registration-input">

--- a/app/views/custom_registrations/new.html.erb
+++ b/app/views/custom_registrations/new.html.erb
@@ -14,7 +14,7 @@
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.text_field :name, autofocus: false, name: 'user[name]', autocomplete: "name", placeholder: "ユーザー名:2〜15文字、英数字" %>
+        <%= f.text_field :name, autofocus: false, name: 'user[name]', autocomplete: "name", placeholder: "ユーザー名:2〜15文字" %>
       </div>
 
       <div class="registration-field">


### PR DESCRIPTION
目的：
ユーザー登録時の入力制限を緩和することが目的です。

内容：
・ユーザー名のバリデーションに文字数制限2~15文字を設定
<img width="1440" alt="スクリーンショット 2024-02-16 23 50 38" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/934edf87-e393-438a-a11f-bcddec134e75">
<img width="1440" alt="スクリーンショット 2024-02-16 23 50 49" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/a3f5452f-cded-4afb-b891-490d8c4f96f5">
<img width="380" alt="スクリーンショット 2024-02-16 23 44 05" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/296d9523-ddef-4f2c-980f-37569ee846bb">
<img width="1440" alt="スクリーンショット 2024-02-16 23 48 27" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/3bc908d3-786b-4f86-a1f8-c4062f7fcb7c">
<img width="1440" alt="スクリーンショット 2024-02-16 23 48 38" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/2a309259-122c-4d57-b512-cbcb13dbb6bd">
<img width="1440" alt="スクリーンショット 2024-02-16 23 48 49" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/8eca9b0b-42af-4548-a8cd-68e39d399b22">
