### PR TITLE
“パスワードバリデーションを8~128文字の英数字許可に変更“

### DIFF
--- a/app/javascript/form_validation.js
+++ b/app/javascript/form_validation.js
@@ -25,7 +25,7 @@ export function validateInput(input) {
     createErrorMessage(input, "⚠️入力してください。");
     input.style.backgroundColor = "rgb(255, 184, 184)";
   } else if (!isPasswordValid(input.value)) {
-    createErrorMessage(input, "⚠️8~128文字、大小英字、数字、記号を含んでください。");
+    createErrorMessage(input, "⚠️8~128文字、英数字（記号は任意）");
     input.style.backgroundColor = "rgb(255, 184, 184)";
   }
 }
@@ -37,7 +37,10 @@ export function isPasswordValid(password) {
   }
 
   // 正規表現を使ってパスワードの形式を検証
-  const regex = /^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)(?=.*?[\W_])[a-zA-Z\d\W_]{8,128}$/;
+  // 大文字小文字を区別せず、記号があってもなくても良い設定
+  // 最低1つの英字と1つの数字が必要
+  // 記号はどちらでもいい
+  const regex = /^(?=.*[a-zA-Z])(?=.*\d)[A-Za-z\d\W_]{8,128}$/;
   return regex.test(password);
 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   # パスワードが変更された場合、または新規作成の場合に検証する
   validates :password, length: { minimum: 8, maximum: 128, too_short: "パスワードは最低%{count}文字必要です。", too_long: "パスワードは最大%{count}文字までです。" }, if: :password_change_or_new_record?
   validates :password, confirmation: { message: "新しいパスワードと確認用パスワードが一致しません。" },
-    format: { with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)(?=.*?[\W_])[a-zA-Z\d\W_]+\z/, message: "パスワードは8文字以上、大小英字、数字、記号を含んでください。" }, if: :password_change_or_new_record?
+    format: { with: /\A(?=.*[a-zA-Z])(?=.*\d)[A-Za-z\d\W_]*\z/, message: "パスワードは8~128で、英字と数字を含んでください（記号は任意）。" }, if: :password_change_or_new_record?
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :confirmable

--- a/app/views/custom_registrations/edit_password.html.erb
+++ b/app/views/custom_registrations/edit_password.html.erb
@@ -6,8 +6,7 @@
 
   <div class="registration-instructions">
     <p>更新後、新しいパスワードで再ログインが必要です。<br>
-    ※パスワードの変更8文字以上、大小英字、数字、記号を<br>
-    含んでください。</p>
+    ※パスワードの変更は8~128文字、英数字を含んでください。</p>
   </div>
 
   <div class="registration-input">

--- a/app/views/custom_registrations/new.html.erb
+++ b/app/views/custom_registrations/new.html.erb
@@ -24,7 +24,7 @@
 
       <div class="registration-field">
         <div class="error-message"></div>
-        <%= f.password_field :password, autofocus: false, name: 'user[password]', autocomplete: "password", placeholder: "パスワード:8~128文字、英数記号含む" %>
+        <%= f.password_field :password, autofocus: false, name: 'user[password]', autocomplete: "password", placeholder: "パスワード:8~128文字の英数字" %>
       </div>
 
       <div class="registration-field">

--- a/app/views/custom_sessions/new.html.erb
+++ b/app/views/custom_sessions/new.html.erb
@@ -16,7 +16,7 @@
       </div>
       <div class="session-field">
         <div class="error-message"></div>
-        <%= f.password_field :password, autofocus: false, autocomplete: "new-password", name: 'user[password]', placeholder: "パスワード:8~128文字、英数記号含む" %>
+        <%= f.password_field :password, autofocus: false, autocomplete: "new-password", name: 'user[password]', placeholder: "パスワード" %>
       </div>
       <div class="session-actions">
         <%= f.submit "ログイン" %>


### PR DESCRIPTION
目的：
パスワードのバリデーション緩和が目的です。

内容：
・パスワードのバリデーションルールを8~128文字の英数字許可に変更

