### PR TITLE
ゲストログイン機能を追加し、手軽な閲覧を実現

### DIFF
--- a/app/controllers/custom_sessions_controller.rb
+++ b/app/controllers/custom_sessions_controller.rb
@@ -40,4 +40,14 @@ class CustomSessionsController < ApplicationController
     #sessions#newへ戻る
     set_flash_and_redirect(:notice, "※ログアウトしました。", new_user_custom_session_path)
   end
+
+  def guest_sign_in
+    user = User.find_or_create_by!(email: 'guest@example.com') do |user|
+      user.name = "ゲスト様"
+      user.password = 'guest123'
+      user.skip_confirmation!
+    end
+    sign_in user
+    set_flash_and_redirect(:notice, "ゲストユーザーとしてログインしました。", root_path)
+  end
 end

--- a/app/views/custom_registrations/new.html.erb
+++ b/app/views/custom_registrations/new.html.erb
@@ -38,6 +38,7 @@
 
       <div class="registration-link">
         <%= link_to 'すでに登録された方はこちら', new_user_custom_session_path %>
+        <%= link_to 'ゲストログイン（閲覧用）', guest_sign_in_path %>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
     get 'users/confirmation/custom_confirm', to: 'custom_confirmations#custom_confirm', as: :custom_user_confirmation
     get 'users/confirmation/resend', to: 'custom_confirmations#show_resend_confirmation_form', as: :show_resend_confirmation_form
 
+    get 'guest_sign_in', to: 'custom_sessions#guest_sign_in'
+
     get 'users/registration', to: 'custom_registrations#new', as: :new_user_custom_registration
     post 'users/registration', to: 'custom_registrations#create', as: :user_custom_registration
     get 'users/session', to: 'custom_sessions#new', as: :new_user_custom_session


### PR DESCRIPTION
目的：
新規訪問者がアカウント作成なしでアプリの機能を試せるようにするという目的です。

内容：
・ゲストログイン機能を追加
・メール確認プロセスをスキップ
・デフォルトのゲストユーザー情報を設定