### PR TITLE
アプリでの「献立」という表現を「レシピ」に統一

### DIFF
--- a/app/assets/stylesheets/_menu-bar.scss
+++ b/app/assets/stylesheets/_menu-bar.scss
@@ -22,18 +22,6 @@
         margin-right: 20px;
       }
     }
-
-    .menu-bar-subtitle {
-      color: #0e0d0d;
-      font-weight: bold;
-      font-size: 12px;
-      margin-left: 17px;
-      @media screen and (max-width: 390px) {
-        color: #0e0d0d;
-        font-weight: bold;
-        font-size: 7px;
-      }
-    }
   }
 
   .menu-bar-right {

--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -189,7 +189,6 @@
     }
   }
 
-  // 献立画面のスタイル
   .ingredient-form-input{
     width: 100%;
     .ingredient-form-field{

--- a/app/assets/stylesheets/user_index.scss
+++ b/app/assets/stylesheets/user_index.scss
@@ -32,7 +32,7 @@
     .menu-item{
       position: relative;
       width: 250px;
-      height: 300px;
+      height: 250px;
       display: flex;
       flex-direction: column;
       justify-content: center;

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -29,7 +29,7 @@ class CartItemsController < ApplicationController
       cart.cart_items.create(menu_id: params[:menu_id], item_count: params[:serving_size])
     end
 
-    flash[:notice] = "献立を選択しました。"
+    flash[:notice] = "レシピを選択しました。"
     redirect_to root_path
   end
 

--- a/app/controllers/concerns/cart_checker.rb
+++ b/app/controllers/concerns/cart_checker.rb
@@ -2,7 +2,7 @@ module CartChecker
 
   def ensure_cart_is_not_empty
     if current_user_cart.nil? || current_user_cart.cart_items.empty?
-      flash[:error] = "献立を選択してください。"
+      flash[:error] = "レシピを選択してください。"
       redirect_to root_path
     end
   end

--- a/app/controllers/concerns/serving_size_handler.rb
+++ b/app/controllers/concerns/serving_size_handler.rb
@@ -36,8 +36,8 @@ module ServingSizeHandler
   private
 
   def set_serving_sizes
-    # 買い出し前の献立にはそれぞれデフォルト値を設定
-    # 買い出し後の献立にはそれぞれ「買い出しを完了した献立数を設定」
+    # 買い出し前のmenuにはそれぞれデフォルト値を設定
+    # 買い出し後のmenuにはそれぞれ「買い出しを完了したmenu数を設定」
     @serving_size = params[:serving_size].present? ? params[:serving_size].to_i : @settings.dig('limits', 'default_serving_size')
     @max_serving_size = params[:max_count].present? ? params[:max_count].to_i : @settings.dig('limits', 'default_max_serving_size')
 

--- a/app/controllers/concerns/shopping_list_updater.rb
+++ b/app/controllers/concerns/shopping_list_updater.rb
@@ -119,9 +119,9 @@ module ShoppingListUpdater
   end
 
 
-  # カート内のアイテムから献立IDと数量のハッシュを生成するメソッド
+  # カート内のアイテムからmenu_idと数量のハッシュを生成するメソッド
   def get_menu_item_counts(cart_items)
-    # 献立とその数量を取得
+    # menuとその数量を取得
     # 具体的にはmenu_idとそのitem_countだけをハッシュとして取得
     #例： {チキンカレーのmenu_id => 2, サラダのmenu_id => 1}
     cart_items.each_with_object({}) do |cart_item, counts|
@@ -132,10 +132,10 @@ module ShoppingListUpdater
 
   # カート内のアイテムに基づいて必要な食材を取得し、それらを必要な量だけ複製するメソッド
   def duplicate_ingredients_for_menu(cart_items, menu_item_counts)
-    # 献立に使う食材データを取得
+    # menuに使う食材データを取得
     menu_ingredients = cart_items.flat_map { |cart_item| cart_item.menu.menu_ingredients }
 
-    # 献立の数量に合わせて食材数を倍にする
+    # menuの数量に合わせて食材数を倍にする
     ingredients_duplicated = []
     menu_ingredients.each do |menu_ingredient|
       # 食材の倍数を取得
@@ -302,7 +302,7 @@ module ShoppingListUpdater
         cart_items = current_user_cart.cart_items
         # ショッピングリストを取得または作成
         shopping_list = current_user_cart.shopping_list || current_user_cart.create_shopping_list
-        # カート内のアイテムから献立IDと数量のハッシュを生成するメソッド
+        # カート内のアイテムからmenu_idと数量のハッシュを生成するメソッド
         menu_item_counts = get_menu_item_counts(cart_items)
 
         # カート内のアイテムに基づいて必要な食材を取得し、それらを必要な量だけ複製する

--- a/app/controllers/cooking_flows_controller.rb
+++ b/app/controllers/cooking_flows_controller.rb
@@ -46,7 +46,7 @@ class CookingFlowsController < ApplicationController
       cart.destroy!
     end
 
-    flash[:notice] = "調理が完了し、選択した献立がリセットされました。"
+    flash[:notice] = "調理が完了し、選択したレシピがリセットされました。"
     redirect_to root_path
 
   rescue ActiveRecord::RecordNotDestroyed => e

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -134,7 +134,7 @@ class MenusController < ApplicationController
     # 画像データがある場合の処理
     if params[:menu].values_at(:encoded_image, :image_content_type).all?
       image_data = Base64.decode64(params[:menu][:encoded_image])
-      filename = "user_#{current_user.id}の献立の画像"
+      filename = "user_#{current_user.id}のレシピの画像"
       menu.image.attach(io: StringIO.new(image_data), filename: filename, content_type: params[:menu][:image_content_type])
     end
 
@@ -162,7 +162,7 @@ class MenusController < ApplicationController
       return
     end
 
-    flash[:notice] = "献立を登録しました。"
+    flash[:notice] = "レシピを登録しました。"
     redirect_to user_custom_menus_path
   end
 
@@ -170,7 +170,7 @@ class MenusController < ApplicationController
   def show
     @menu = Menu.find(params[:id])
 
-    # 重複した献立を基準の単位に変換し、合算する
+    # 重複したmenuを基準の単位に変換し、合算する
     menu_ingredients = MenuIngredient.where(menu_id: @menu.id)
     ingredients = menu_ingredients.includes(:ingredient).map(&:ingredient)
     aggregated_ingredients = aggregate_ingredients(ingredients)
@@ -235,13 +235,6 @@ class MenusController < ApplicationController
   def update
     menu = Menu.find(params[:id])
 
-    # 画像データがある場合の処理
-    if params[:menu].values_at(:encoded_image, :image_content_type).all?
-      image_data = Base64.decode64(params[:menu][:encoded_image])
-      filename = "user_#{current_user.id}の献立の画像"
-      menu.image.attach(io: StringIO.new(image_data), filename: filename, content_type: params[:menu][:image_content_type])
-    end
-
     # 食材データを「@menu.steps」に格納
     if params[:menu][:recipe_steps].present?
       filtered_steps = filter_steps_data(params[:menu][:recipe_steps])
@@ -254,6 +247,13 @@ class MenusController < ApplicationController
       filtered_ingredients = filter_ingredients(params[:menu][:ingredients])
       # インスタンス化してmenuに関連付ける
       menu.ingredients = create_ingredient_instances(filtered_ingredients)
+    end
+
+    # 画像データがある場合の処理
+    if params[:menu].values_at(:encoded_image, :image_content_type).all?
+      image_data = Base64.decode64(params[:menu][:encoded_image])
+      filename = "user_#{current_user.id}のレシピの画像"
+      menu.image.attach(io: StringIO.new(image_data), filename: filename, content_type: params[:menu][:image_content_type])
     end
 
     begin
@@ -294,7 +294,7 @@ class MenusController < ApplicationController
       return
     end
 
-    flash[:notice] = "献立が更新されました。"
+    flash[:notice] = "レシピが更新されました。"
     redirect_to user_menu_path(user_id: current_user.id, id: params[:menu][:menu_id])
   end
 
@@ -304,12 +304,12 @@ class MenusController < ApplicationController
     menu = Menu.find(params[:menu_id])
     # menu_idに該当するshopping_list_menusデータがあるかチェック
     if menu.shopping_list_menus.exists?
-      flash[:error] = "この献立は現在選択されています。"
+      flash[:error] = "このレシピは現在選択されています。"
       redirect_to user_menu_path(menu_id: menu.id)
     else
       # menuデータを削除
       menu.destroy
-      flash[:notice] = "献立を削除しました。"
+      flash[:notice] = "レシピを削除しました。"
       redirect_to user_custom_menus_path
     end
   end
@@ -410,7 +410,7 @@ class MenusController < ApplicationController
     end
 
     if current_user_cart.cart_items.exists?(menu_id: params[:menu_id])
-      flash[:error] = "この献立は現在選択されているため、編集（削除）はできません。"
+      flash[:error] = "このレシピは現在選択されているため、編集（削除）はできません。"
       redirect_to user_menu_path(menu_id: params[:menu_id])
     end
   end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -54,7 +54,7 @@ class ShoppingListsController < ApplicationController
         # その中に同じ食材があれば合算する処理
         aggregate_and_update_checked_items(checked_items)
 
-        # カート内のアイテムから献立IDと数量のハッシュを生成するメソッド
+        # カート内のアイテムからmenu_idと数量のハッシュを生成するメソッド
         menu_item_counts = get_menu_item_counts(cart_items)
         # カート内のアイテムに基づいて必要な食材を取得し、それらを必要な量だけ複製する
         ingredients_duplicated = duplicate_ingredients_for_menu(cart_items, menu_item_counts)
@@ -97,7 +97,7 @@ class ShoppingListsController < ApplicationController
     return
   end
 
-  # 献立を減少（削除）を行う際に食材リストですでにチェックされている値（例：✔︎鶏肉 200g）が
+  # menuを減少（削除）を行う際に食材リストですでにチェックされている値（例：✔︎鶏肉 200g）が
   # 変更される場合に確認ダイヤログを出す指示をするアクション
   def check_items
     # パラメータからmenu_idとitem_countを取得
@@ -118,7 +118,7 @@ class ShoppingListsController < ApplicationController
     # チェック済みの食材リストデータで同じ食材があれば合算する処理
     # 例：✔︎鶏肉 200g, ✔︎鶏肉 100g → ✔︎鶏肉 300g
     aggregate_and_update_checked_items(checked_items)
-    # カートの中にある献立データを取得
+    # カートの中にあるmenuデータを取得
     cart_items = current_user_cart.cart_items
 
     # cart_itemsから指定されたmenu_idを持つアイテムを更新または除外
@@ -126,7 +126,7 @@ class ShoppingListsController < ApplicationController
     # 減少（削除）したデータ作成
 
     # 数量変更の場合の処理
-    # 献立の作る数量を減少させた場合の食材リストデータ（仮）を作成
+    # menuの作る数量を減少させた場合の食材リストデータ（仮）を作成
     if item_count_to_remove
       # デフォルトのアイテム数減少量
       default_item_count_decrement = @settings.dig('cart', 'default_item_count_decrement')
@@ -141,7 +141,7 @@ class ShoppingListsController < ApplicationController
         updated_cart_items << item unless item.menu_id.to_s == menu_id_to_remove
       end
 
-    # 献立を削除させた場合の食材リストデータを作成
+    #menuを削除させた場合の食材リストデータを作成
     else
       # menu_id_to_remove に該当するアイテムを除外
       updated_cart_items = cart_items.reject { |item| item.menu_id.to_s == menu_id_to_remove }
@@ -154,7 +154,7 @@ class ShoppingListsController < ApplicationController
       return
     end
 
-    # 食材リストデータ（仮）から献立IDと数量のハッシュを生成
+    # 食材リストデータ（仮）からmenuIDと数量のハッシュを生成
     menu_item_counts = get_menu_item_counts(updated_cart_items)
     # 食材リストデータ（仮）に基づいて必要な食材を取得し、必要な量だけ複製
     ingredients_duplicated = duplicate_ingredients_for_menu(updated_cart_items, menu_item_counts)
@@ -176,7 +176,7 @@ class ShoppingListsController < ApplicationController
       return
     end
 
-    # 削除した献立の食材データは全て未チェックだった場合の処理
+    # 削除したmenuの食材データは全て未チェックだった場合の処理
     match_result = check_items_match(shopping_list, shopping_list_items_instances)
     if match_result
       render json: { requires_attention: false }

--- a/app/javascript/add_form.js
+++ b/app/javascript/add_form.js
@@ -208,7 +208,7 @@ function updateForm(){
   // 1は、少なくとも1つのフォームが存在することを意味し、この条件を満たした場合のみフォームの再作成を行う。
   const minFormCount = INGREDIENT_MIN_FORM_COUNT;
 
-  // 献立を設定された状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
+  // menuを設定された状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
   if (formCount >= minFormCount) {
     const createFormCount = formCount
     createNewForms(createFormCount, parsedIngredients, unitIds)

--- a/app/javascript/check_items.js
+++ b/app/javascript/check_items.js
@@ -30,7 +30,7 @@ function setupDeleteButtonListeners(buttonClass) {
       .then(response => response.json())
       .then(data => {
         if (data.requires_attention) {
-          if (confirm('献立の変更により、既にチェックされた食材の数量が変わるか、リストから削除されます。この変更を適用しますか？')) {
+          if (confirm('レシピの変更により、既にチェックされた食材の数量が変わるか、リストから削除されます。この変更を適用しますか？')) {
             form.submit();
           }
         } else {

--- a/app/javascript/dynamic_step_forms.js
+++ b/app/javascript/dynamic_step_forms.js
@@ -59,7 +59,7 @@ function updateStepForm(){
   // 最小フォームカウント：この値は、フォームが存在している（つまりフォームの数が0より大きい）ことを確認するために使用される。
   // 1は、少なくとも1つのフォームが存在することを意味し、この条件を満たした場合のみフォームの再作成を行う。
   const minFormStepCount = INGREDIENT_MIN_FORM_STEPS_COUNT;
-  // 献立を設定された状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
+  // menuを設定された状態で確認画面へ移動し、そこから再編集で入力画面に戻った時の処理
   if (formStepCount >= minFormStepCount) {
     // 編集時に設定されていたフォームの数を設定
     const StepCount = formStepCount

--- a/app/views/cooking_flows/index.html.erb
+++ b/app/views/cooking_flows/index.html.erb
@@ -6,7 +6,7 @@
 
 
   <div class="menu-overview">
-    <p>　作る予定の献立　</p>
+    <p>　作る予定のレシピ　</p>
   </div>
 
   <div class="cooking-flow-body">
@@ -58,7 +58,7 @@
   <% end %>
 
   <div class="button-container">
-    <%= button_to '調理完了', complete_cooking_flow_path(@cooking_flow), method: :patch, class: 'complete-button', form: { data: { turbo_confirm: "お疲れ様です！調理完了のため選択していた献立をリセットします。よろしいでしょうか？" } } %>
+    <%= button_to '調理完了', complete_cooking_flow_path(@cooking_flow), method: :patch, class: 'complete-button', form: { data: { turbo_confirm: "お疲れ様です！調理完了のため選択していたレシピをリセットします。よろしいでしょうか？" } } %>
 
     <%= button_to "戻る", root_path, class: "back-button", method: :get %>
   </div>

--- a/app/views/menus/_form_fields.html.erb
+++ b/app/views/menus/_form_fields.html.erb
@@ -1,22 +1,22 @@
 <div id="menu-error_name" class="menu-error"></div>
 <div class="name-form-field">
-  <%= f.text_field :menu_name, autofocus: false, id: "menu_name", autocomplete: "menu_name", placeholder: "献立名(最大20字)" %>
+  <%= f.text_field :menu_name, autofocus: false, id: "menu_name", autocomplete: "menu_name", placeholder: "レシピ名(最大20字)" %>
 </div>
 
 
 <div class ="contents-title">
-  <p>２.献立説明を設定</p>
+  <p>２.レシピ説明を設定</p>
 </div>
 
 <div id="menu-error-menu-contents" class="menu-error"></div>
 <div class="menu-contents-field">
-  <%= f.text_field :menu_contents, autofocus: false, id: "menu_contents", autocomplete: "menu_contents", placeholder: "献立の説明(最大20字)" %>
+  <%= f.text_field :menu_contents, autofocus: false, id: "menu_contents", autocomplete: "menu_contents", placeholder: "レシピの説明(最大20字)" %>
 </div>
 
 <div class ="contents-title">
-  <p>３.献立画像を設定</p>
+  <p>３.レシピ画像を設定</p>
 </div>
 
 <div class="image-field">
-  <%= f.file_field :image, autofocus: false, autocomplete: "image", placeholder: "献立の写真", id: "menu_image" %>
+  <%= f.file_field :image, autofocus: false, autocomplete: "image", placeholder: "レシピの写真", id: "menu_image" %>
 </div>

--- a/app/views/menus/_menu_confirm_details.html.erb
+++ b/app/views/menus/_menu_confirm_details.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div class ="contents-title">
-    <p>　献立名　</p>
+    <p>　レシピ名　</p>
   </div>
   <div class ="menu-contents">
     <%= menu.menu_name %>
@@ -13,7 +13,7 @@
 
   <% if menu.menu_contents.present? %>
     <div class ="contents-title">
-      <p>　献立の説明　</p>
+      <p>　レシピの説明　</p>
     </div>
     <div class ="menu-contents">
       <%= menu.menu_contents %>
@@ -22,7 +22,7 @@
   <% end %>
 
   <div class ="contents-title">
-    <p>　献立画像　</p>
+    <p>　レシピ画像　</p>
   </div>
   <div class ="menu-contents">
     <% image_data_url = image_data_url || params.dig(:menu, :image_data_url) %>

--- a/app/views/menus/custom_menus.html.erb
+++ b/app/views/menus/custom_menus.html.erb
@@ -3,12 +3,12 @@
 
 <div class="menus-container">
   <nav class="menu-list-container">
-    <%= link_to "サンプル献立", sample_menus_path, class: "menu-list-heading", method: :get %>
-    <%= link_to "オリジナル献立", user_custom_menus_path(current_user), class: "main-menu-list-heading", method: :get %>
+    <%= link_to "サンプルレシピ", sample_menus_path, class: "menu-list-heading", method: :get %>
+    <%= link_to "オリジナルレシピ", user_custom_menus_path(current_user), class: "main-menu-list-heading", method: :get %>
   </nav>
 
   <div class="menus_list">
-    <%= button_to "オリジナル献立作成", new_user_menu_path(current_user.id), class: "original-menu-button", method: :get, data: { turbo: false } %>
+    <%= button_to "オリジナルレシピ作成", new_user_menu_path(current_user.id), class: "original-menu-button", method: :get, data: { turbo: false } %>
 
 
     <%= turbo_frame_tag 'original_menus_frame' do %>

--- a/app/views/menus/edit.html.erb
+++ b/app/views/menus/edit.html.erb
@@ -2,11 +2,11 @@
   <div class="menu-form-container" data-user-id="<%= current_user.id %>">
 
     <div class="menu-form-title">
-      <h1>献立修正</h1>
+      <h1>レシピ修正</h1>
     </div>
 
     <div class ="contents-title">
-      <p>１.献立情報入力</p>
+      <p>１.レシピ情報入力</p>
     </div>
 
     <div class="menu-form-input">

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -2,11 +2,11 @@
   <div class="menu-form-container" data-user-id="<%= current_user.id %>">
 
     <div class="menu-form-title">
-      <h1>献立登録</h1>
+      <h1>レシピ登録</h1>
     </div>
 
     <div class ="contents-title">
-      <p>１.献立名の設定<span class="required-text">（※必須）</span></p>
+      <p>１.レシピ名の設定<span class="required-text">（※必須）</span></p>
     </div>
 
     <div class="menu-form-input">

--- a/app/views/menus/sample_menus.html.erb
+++ b/app/views/menus/sample_menus.html.erb
@@ -4,8 +4,8 @@
 <div class="menus-container">
 
   <nav class="menu-list-container">
-    <%= link_to "サンプル献立", sample_menus_path, class: "main-menu-list-heading", method: :get %>
-    <%= link_to "オリジナル献立", user_custom_menus_path(current_user), class: "menu-list-heading", method: :get %>
+    <%= link_to "サンプルレシピ", sample_menus_path, class: "main-menu-list-heading", method: :get %>
+    <%= link_to "オリジナルレシピ", user_custom_menus_path(current_user), class: "menu-list-heading", method: :get %>
   </nav>
 
   <div class="menus_list">

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -1,7 +1,6 @@
 <div class="menu-bar">
   <div class="menu-bar-left">
     <span class="menu-bar-app-name">Autonomy</span>
-    <span class="menu-bar-subtitle">~自炊で毎日の健康管理を~</span>
   </div>
   <div class="menu-bar-right">
     <%= link_to user_my_page_path(current_user.id), class: "menu-icon-link" do %>

--- a/app/views/shared/_menu_details.html.erb
+++ b/app/views/shared/_menu_details.html.erb
@@ -1,11 +1,11 @@
 
 <div class="menu-show-list">
   <div class="menu-show-title">
-    <h1>献立情報</h1>
+    <h1>レシピ情報</h1>
   </div>
 
   <div class="show-contents-title">
-    <p>　献立名　</p>
+    <p>　レシピ名　</p>
   </div>
 
   <div class="menu-contents">
@@ -14,7 +14,7 @@
 
   <% if menu.menu_contents.present? %>
     <div class="show-contents-title">
-      <p>　献立の説明　</p>
+      <p>　レシピの説明　</p>
     </div>
     <div class ="menu-contents">
       <%= menu.menu_contents %>
@@ -22,7 +22,7 @@
   <% end %>
 
   <div class="show-contents-title">
-    <p>　献立画像　</p>
+    <p>　レシピ画像　</p>
   </div>
 
   <div class ="menu-contents">

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -6,7 +6,7 @@
 
   <div class="cooking-menu-list">
     <div class="list-contents-title">
-      <p>作る予定の献立</p>
+      <p>作る予定のレシピ</p>
     </div>
 
     <div class="shopping-menu-list">
@@ -23,7 +23,7 @@
 
     <div class="ingredient-list">
       <% if @shopping_lists.empty? %>
-        <p>購入する食材はありません。</p>
+        <p>必要な食材はありません。</p>
       <% else %>
         <% @shopping_lists.each do |category_id, ingredients| %>
           <div class="category-list">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 <div class="menu-index-container" id="menu-index">
 
   <div class="menu-heading">
-    <h3>選択された献立</h3>
+    <h3>選択されたレシピ</h3>
   </div>
 
   <% if @cart_items.present? %>
@@ -12,7 +12,7 @@
         <div class="menu-item">
           <%= button_to '✖️', cart_item_path(cart_item), method: :delete, class: "delete-button", params: { menu_id: cart_item.menu_id } %>
 
-          <%= image_tag(rails_blob_path(cart_item.menu.image.variant(resize_to_fill: [220, 190])), class: "rounded-image") %>
+          <%= image_tag(rails_blob_path(cart_item.menu.image.variant(resize_to_fill: [220, 140])), class: "rounded-image") %>
           <div class="menu-item-title"><%= truncate(cart_item.menu.menu_name, length: 10, omission: '..') %></div>
 
           <div class="menu-item-count">
@@ -28,11 +28,11 @@
       <% end %>
     </div>
   <% else %>
-    <p class="empty-cart-message">献立が選択されていません。</p>
+    <p class="empty-cart-message">レシピが選択されていません。</p>
   <% end %>
 
   <div class="button-set-container">
-    <%= button_to "献立を選ぶ", sample_menus_path, class: "button-style bg-standard-menu", method: :get %>
+    <%= button_to "レシピを作る・選ぶ", sample_menus_path, class: "button-style bg-standard-menu", method: :get %>
     <%= button_to "買い物リスト", shopping_lists_path, class: "button-style bg-shopping-list", method: :post, id: "shopping-list" %>
     <%= button_to "レシピを確認", cooking_flows_path, class: "button-style bg-standard-menu", method: :get %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,10 @@ Rails.application.routes.draw do
   post '/users/:user_id/menus/confirm', to: 'menus#confirm', as: :confirm_user_menu
   post 'users/:user_id/menus/units', to: 'menus#units'
 
-  # ユーザーが作成した献立用のルーティング
+  # ユーザーが作成したmenu用のルーティング
   get 'users/:user_id/custom_menus', to: 'menus#custom_menus', as: :user_custom_menus
 
-  # 標準献立用のルーティング
+  # 標準menu用のルーティング
   get 'sample_menus', to: 'menus#sample_menus', as: :sample_menus
 
   # CartItem#createへのルーティング


### PR DESCRIPTION
目的：
アプリ内の表現を明確にし、ユーザーの理解を深めるために「献立」を「レシピ」に統一するという目的です。

内容：
・アプリ内の全ての「献立」表現を「レシピ」に変更
・関連するヘルプテキストとラベルの更新