### PR TITLE
テスト環境のビュースタイル崩れを修正

### DIFF
--- a/app/assets/stylesheets/cooking_flows.scss
+++ b/app/assets/stylesheets/cooking_flows.scss
@@ -56,8 +56,11 @@
   .ingredients-section{
     width: 40%;
     padding-bottom: 30px;
-    @media screen and (max-width: 1100px) {
-      width: 65%;
+    @media screen and (max-width: 800px) {
+      width: 50%;
+    }
+    @media screen and (max-width: 700px) {
+      width: 80%;
     }
 
     .ingredient-overview{

--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -162,6 +162,13 @@
               font-size: 16px;
             }
 
+            .select-dropdown{
+              background-color: #ffffff;
+              border-radius: 0px;
+              padding: 8px 16px 8px 0;
+              font-size: 16px;
+            }
+
             .step-description {
               .text-field {
                 width: calc(100% - 10px);


### PR DESCRIPTION
目的：
テスト環境におけるUIの整合性を保つため、ドロップダウンメニューのビュースタイルの崩れを修正することが目的です。

内容：
・セレクトボックスの左側のpaddingを削除してデザインを整えました
・他のUI要素に影響を与えずに特定のスタイルのみを調整