### PR TITLE
レシピ最大数量を10に制限し、ログアウト後LPへリダイレクト

### DIFF
--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -55,8 +55,12 @@ class CartItemsController < ApplicationController
 
   def increment
     cart_item = CartItem.find_by(id: params[:id])
-    cart_item.increment!(:item_count)
 
+    max_item_count = @settings.dig('limits', 'default_max_serving_size')
+    # item_countが10以上の場合は処理を終了する
+    return if cart_item.item_count >= max_item_count
+
+    cart_item.increment!(:item_count)
     redirect_back(fallback_location: root_path)
   end
 

--- a/app/controllers/custom_sessions_controller.rb
+++ b/app/controllers/custom_sessions_controller.rb
@@ -38,7 +38,7 @@ class CustomSessionsController < ApplicationController
     #セッションの完全な処理
     reset_session
     #sessions#newへ戻る
-    set_flash_and_redirect(:notice, "※ログアウトしました。", new_user_custom_session_path)
+    set_flash_and_redirect(:notice, "※ログアウトしました。", landing_pages_show_path)
   end
 
   def guest_sign_in

--- a/app/views/menus/_menu_list.html.erb
+++ b/app/views/menus/_menu_list.html.erb
@@ -5,7 +5,7 @@
       <div class="menu-item-title"><%= truncate(menu.menu_name, length: 10, omission: '..') %></div>
       <div class="button-group">
         <%= button_to '選択', cart_items_path(menu_id: menu.id, serving_size: serving_size), method: :post, class: 'select-button', data: { turbo: false } %>
-        <%= button_to '詳細', user_menu_path(current_user, menu), class: 'details-button', method: :get, data: { turbo: false } %>
+        <%= button_to 'レシピ', user_menu_path(current_user, menu), class: 'details-button', method: :get, data: { turbo: false } %>
       </div>
     </div>
   <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,7 @@ limits:
   max_total_items: 20
   min_serving_size: 1
   default_serving_size: 1
-  default_max_serving_size: 35
+  default_max_serving_size: 10
   min_items_to_process: 1
   min_items_to_decrement: 1
   unique_unit_id_threshold: 1


### PR DESCRIPTION
目的：
カート内のレシピ数量上限を10に設定し、ユーザーがログアウトした際にランディングページへ自動的にリダイレクトさせることで、利便性を向上させるという目的です。

内容：
・カート内のレシピ数量を最大10個に制限
・ユーザーがログアウトした際にランディングページへリダイレクトする機能を追加