### PR TITLE
“レシピ登録の「数量」に動的・カスタムバリデーションを追加

### DIFF
--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -204,8 +204,8 @@ function validateIngredientQuantity(quantityInput, errorDiv) {
   const quantityValue = quantityInput.value.trim();
 
   // 数量が半角数字ではない、または空の場合にエラーメッセージを表示
-  if (!quantityValue || !isHalfWidthNumber(quantityValue)) {
-    errorDiv.textContent = "⚠️必須：半角数字（小数可、先頭0不可）で数量の設定してください。";
+  if (!quantityValue || !isValidDecimalPlace(quantityValue)) {
+    errorDiv.textContent = "⚠️必須：999以下、小数点第1位までの半角数字で入力";
     quantityInput.style.backgroundColor = "rgb(255, 184, 184)";
     errorDiv.style.color = "red";
     return false;
@@ -217,7 +217,9 @@ function validateIngredientQuantity(quantityInput, errorDiv) {
   }
 }
 
-// 半角数字のみかどうかをチェックするヘルパー関数
-function isHalfWidthNumber(value) {
-  return /^(?!0\d)\d*(\.\d+)?$/.test(value);
+// 小数点第1位までの数値であるかを検証する関数
+function isValidDecimalPlace(value) {
+  // 数値が999以下かつ小数点第1位までであるか検証
+  // 正規表現では、整数部が1〜3桁の数値、小数点がある場合は小数第1位までの数値であることを確認します
+  return /^([0-9]{1,3})(\.[0-9]?)?$/.test(value) && parseFloat(value) <= 999;
 }

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -12,11 +12,45 @@ class Ingredient < ApplicationRecord
   validates :quantity, presence: { message: common_error_message }, length: { maximum: 10, too_long: common_error_message }, unless: :skip_quantity_validation?
   validates :unit_id, presence: { message: common_error_message }
 
+  validate :custom_quantity_validation, unless: :skip_quantity_validation?
+
   private
   # 特定の条件下で'quantity'バリデーションをスキップ
   def skip_quantity_validation?
     settings = YAML.load_file(Rails.root.join('config', 'settings.yml'))
     unit_id == settings.dig('ingredient', 'no_quantity_unit_id')
+  end
+
+  def custom_quantity_validation
+    settings = YAML.load_file(Rails.root.join('config', 'settings.yml'))
+
+    # 設定ファイルから値をロード
+    max_quantity_value = settings.dig('limits', 'max_quantity_value')
+    max_integer_digits = settings.dig('limits', 'max_integer_digits')
+    max_decimal_places = settings.dig('limits', 'max_decimal_places')
+
+    # 初期状態ではエラーはないと仮定
+    has_error = false
+
+    # 数値が設定値以下であるかどうかをチェック
+    if quantity.present? && quantity > max_quantity_value
+      has_error = true
+    end
+
+    # 整数部が設定値の桁数以下であるかどうかをチェック
+    if quantity.present? && quantity.to_i.to_s.length > max_integer_digits
+      has_error = true
+    end
+
+    # 小数点がある場合、小数点以下の桁数が設定値以下であるかをチェック
+    if quantity.present? && quantity.to_s.include?('.') && quantity.to_s.split('.').last.length > max_decimal_places
+      has_error = true
+    end
+
+    # has_errorがtrueの場合、共通エラーメッセージを追加
+    if has_error
+      errors.add(:quantity, '登録中に予期せぬエラーが発生しました。')
+    end
   end
 
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,9 @@ limits:
   min_items_to_process: 1
   min_items_to_decrement: 1
   unique_unit_id_threshold: 1
+  max_quantity_value: 999
+  max_integer_digits: 3
+  max_decimal_places: 1
 
 confirmation:
   token_validity_hours: 24


### PR DESCRIPTION
目的：
レシピ登録時の「数量」フィールドに対して、ユーザー入力をより正確に制御し、データの整合性を保つために、動的およびカスタムバリデーションを追加するという目的です。

内容：
・「数量」フィールドに999以下であることを確認する動的バリデーションを実装
・「数量」フィールドが整数部分3桁、小数点1位までの入力を許可するカスタムバリデーションを設定
