### PR TITLE
レシピ画像の動的・バックエンドバリデーションを実装

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -77,6 +77,12 @@ class MenusController < ApplicationController
       @encoded_image = params[:menu][:encoded_image]
     end
 
+    # アップロードされた画像がある場合のみバリデーションを行い、問題があれば処理を中断
+    if params[:menu][:image].present? && validate_uploaded_image(params[:menu][:image])
+      handle_general_error
+      return
+    end
+
     # 画像が新規アップロードされた場合、uploaded_fileを作成し既存データを上書き
     if params[:menu][:image].present?
       uploaded_file = params[:menu][:image]
@@ -429,5 +435,21 @@ class MenusController < ApplicationController
     steps_array.map do |value|
       RecipeStep.new(recipe_step_category_id: value[:recipe_step_category_id], description: value[:description])
     end
+  end
+
+  # アップロードされた画像のバリデーションを行うメソッド
+  def validate_uploaded_image(uploaded_file)
+    valid_content_types = %w[image/jpeg image/png]
+    max_size_in_megabytes = @settings.dig('limits', 'max_image_size_in_megabytes')
+
+    if !valid_content_types.include?(uploaded_file.content_type)
+      return true
+    end
+
+    if uploaded_file.size > max_size_in_megabytes.megabytes
+      return true
+    end
+
+    return false
   end
 end

--- a/app/javascript/menu_validation.js
+++ b/app/javascript/menu_validation.js
@@ -19,6 +19,10 @@ document.addEventListener('submit', function(event) {
     hasError = true;
   }
 
+  if (!validateMenuImage()){
+    hasError = true;
+  }
+
   if (!validateStepFormFields(event)) {
     hasError = true;
   }
@@ -222,4 +226,32 @@ function isValidDecimalPlace(value) {
   // 数値が999以下かつ小数点第1位までであるか検証
   // 正規表現では、整数部が1〜3桁の数値、小数点がある場合は小数第1位までの数値であることを確認します
   return /^([0-9]{1,3})(\.[0-9]?)?$/.test(value) && parseFloat(value) <= 999;
+}
+
+function validateMenuImage() {
+  const fileInput = document.getElementById('menu_image');
+  const errorDiv = document.getElementById('menu-error-image');
+  const file = fileInput.files[0];
+  const validImageTypes = ['image/jpeg', 'image/png'];
+  const ONE_KB = 1024; // 1キロバイトは1024バイト
+  const ONE_MB = ONE_KB * 1024; // 1メガバイトは1024キロバイト
+  const MAX_FILE_SIZE = 5 * ONE_MB; // 最大ファイルサイズを5MBに設定
+
+  errorDiv.textContent = '';
+  errorDiv.style.color = '';
+  errorDiv.style.backgroundColor = '';
+
+  if (!file) {
+    return true;
+  }
+
+  // ファイルタイプとファイルサイズの検証を1つの条件でチェック
+  if (!validImageTypes.includes(file.type) || file.size > MAX_FILE_SIZE) {
+    // エラーメッセージとスタイルの設定
+    errorDiv.textContent = '画像は5MB以下のJPEG, PNGファイルを設定してください。';
+    errorDiv.style.color = 'red';
+    return false;
+  }
+
+  return true;
 }

--- a/app/views/menus/_form_fields.html.erb
+++ b/app/views/menus/_form_fields.html.erb
@@ -17,6 +17,7 @@
   <p>３.レシピ画像を設定</p>
 </div>
 
+<div id="menu-error-image" class="menu-error"></div>
 <div class="image-field">
   <%= f.file_field :image, autofocus: false, autocomplete: "image", placeholder: "レシピの写真", id: "menu_image" %>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,7 @@ limits:
   max_quantity_value: 999
   max_integer_digits: 3
   max_decimal_places: 1
+  max_image_size_in_megabytes: 5
 
 confirmation:
   token_validity_hours: 24


### PR DESCRIPTION
目的：
レシピ画像に関するユーザー体験の向上とデータの整合性を確保するため、フロントエンドとバックエンドの両方でバリデーションを強化します。

内容：
・フロントエンドでの画像ファイル形式とサイズの動的バリデーションを実装
・バックエンドで画像ファイルの形式とサイズに対するカスタムバリデーションを設定
・エラーメッセージをユーザーに表示し、不適切なファイルのアップロードを事前に防止

※画像は5MB以下のJPEG, PNGファイルを設定