### PR TITLE
単位表示修正とユーザー非紐付レシピ表示不具合を解消

### DIFF
--- a/app/controllers/concerns/ingredient_scaler.rb
+++ b/app/controllers/concerns/ingredient_scaler.rb
@@ -4,9 +4,28 @@ module IngredientScaler
 
   def scale_ingredients(ingredients, menu_count)
     menu_count = menu_count.to_i
+    ingredient_settings = @settings['ingredient']
+    exception_ingredient_quantity = ingredient_settings['exception_ingredient_quantity']
+    no_quantity_unit_id = ingredient_settings['no_quantity_unit_id']
+    default_unit_id = ingredient_settings['default_unit_id']
+    min_items_to_scale = @settings.dig('limits', 'min_items_to_scale')
+
     ingredients.map do |ingredient|
       new_ingredient = ingredient.dup
-      new_ingredient.quantity *= menu_count
+
+      if menu_count == min_items_to_scale
+        new_ingredient_quantity = new_ingredient.quantity
+      end
+
+      if menu_count > min_items_to_scale
+        new_ingredient_quantity = new_ingredient.quantity || exception_ingredient_quantity
+        new_ingredient.quantity = new_ingredient_quantity *= menu_count
+      end
+
+      if new_ingredient.unit_id == no_quantity_unit_id && menu_count > min_items_to_scale
+        new_ingredient.unit_id = default_unit_id
+      end
+
       new_ingredient
     end
   end

--- a/app/controllers/cooking_flows_controller.rb
+++ b/app/controllers/cooking_flows_controller.rb
@@ -105,12 +105,17 @@ class CookingFlowsController < ApplicationController
       menu_name = menus[menu_id].menu_name
       unit_name = units[ingredient.unit_id].unit_name
 
-      # 食材の量をメニュー項目ごとのカウントに基づいて調整
-      quantity = ingredient.quantity * menu_item_counts[menu_id]
+      # ingredient.quantityがnilの場合のみデータを複製
+      # ingredient.quantityが存在しない、または0の場合にはデータを複製
+      if ingredient.quantity.nil?
+        duplicates = Array.new(menu_item_counts[menu_id]) { { ingredient: ingredient, unit_name: unit_name } }
+      else
+        quantity = ingredient.quantity * menu_item_counts[menu_id]
+        duplicates = [{ ingredient: ingredient, quantity: quantity, unit_name: unit_name }]
+      end
 
-      # メニューIDごとに食材データを集約
       grouped[menu_id] ||= {menu_name: menu_name, ingredients: []}
-      grouped[menu_id][:ingredients] << {ingredient: ingredient, quantity: quantity, unit_name: unit_name}
+      grouped[menu_id][:ingredients].concat(duplicates)
     end
 
     # メニューIDごとに集約したデータを配列に変換して返す

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -16,10 +16,12 @@ class MenusController < ApplicationController
 
 
   def sample_menus
-    menu_ids = UserMenu.where(user_id: current_user.id).pluck(:menu_id)
-    @default_menus = paginate(Menu.where.not(id: menu_ids))
+    # UserMenuに存在する全てのmenu_idを取得
+    used_menu_ids = UserMenu.pluck(:menu_id)
+    # これらのmenu_idに紐づいていないMenuのデータを取得
+    @default_menus = paginate(Menu.where.not(id: used_menu_ids))
     # ユーザーに紐づいていないメニュー項目の総数を取得
-    @total_menus_count = Menu.where.not(id: menu_ids).count
+    @total_menus_count = Menu.where.not(id: used_menu_ids).count
   end
 
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,8 @@ pagination:
 
 ingredient:
   no_quantity_unit_id: 17
+  exception_ingredient_quantity: 0.5
+  default_unit_id: 1
 
 limits:
   max_total_items: 20
@@ -18,6 +20,7 @@ limits:
   max_integer_digits: 3
   max_decimal_places: 1
   max_image_size_in_megabytes: 5
+  min_items_to_scale: 1
 
 confirmation:
   token_validity_hours: 24


### PR DESCRIPTION
目的：
レシピ表示時の単位エラー修正と他ユーザーレシピの誤表示を改善し、正確な情報提供を目指すという目的です。

内容：
・特定単位「少々」表示時のエラーを修正
・サンプルレシピ表示で他ユーザーのレシピが表示されないように改善
