### PR TITLE
レシピ食材表示をユーザーに優しく一部単位を統一して表示

### DIFF
--- a/app/controllers/cooking_flows_controller.rb
+++ b/app/controllers/cooking_flows_controller.rb
@@ -92,42 +92,150 @@ class CookingFlowsController < ApplicationController
     meat_prep_steps = cooking_steps.select { |step| step.recipe_step.recipe_step_category_id == categories['meat_prep'] }
     other_prep_steps = cooking_steps.select { |step| step.recipe_step.recipe_step_category_id == categories['other_prep'] }
     other_steps = cooking_steps.reject { |step| [categories['vegetable_prep'], categories['meat_prep'], categories['other_prep']].include?(step.recipe_step.recipe_step_category_id) }
-  
+
     sorted_steps = vegetable_prep_steps + other_prep_steps + meat_prep_steps + other_steps
     sorted_steps
   end
 
   # ingredientデータの構築
   def build_ingredients_data(menu_ingredients, menus, units, menu_item_counts)
-    grouped_ingredients = menu_ingredients.each_with_object({}) do |menu_ingredient, grouped|
-      menu_id = menu_ingredient.menu_id
-      ingredient = menu_ingredient.ingredient
-      menu_name = menus[menu_id].menu_name
-      unit_name = units[ingredient.unit_id].unit_name
+    processed_results = {}
+    # menu_idごとのデータを格納するハッシュを初期化
+    duplicate_ingredients = duplicate_ingredients(menu_ingredients, menu_item_counts)
+    # 各menu_idごとに「特殊なunit_id」と「それ以外」のデータを分けて格納する
+    categorized_ingredients = duplicate_ingredients.each_with_object({}) do |(menu_id, ingredients), result|
+      # 特殊なunit_id（例: 17）のデータとそれ以外のデータを分ける
+      special_unit_ids, other_units = ingredients.partition { |ingredient| ingredient.unit_id == 17 }
 
-      # ingredient.quantityがnilの場合のみデータを複製
-      # ingredient.quantityが存在しない、または0の場合にはデータを複製
-      if ingredient.quantity.nil?
-        duplicates = Array.new(menu_item_counts[menu_id]) { { ingredient: ingredient, unit_name: unit_name } }
-      else
-        quantity = ingredient.quantity * menu_item_counts[menu_id]
-        duplicates = [{ ingredient: ingredient, quantity: quantity, unit_name: unit_name }]
-      end
-
-      grouped[menu_id] ||= {menu_name: menu_name, ingredients: []}
-      grouped[menu_id][:ingredients].concat(duplicates)
-    end
-
-    # メニューIDごとに集約したデータを配列に変換して返す
-    grouped_ingredients.map do |menu_id, data|
-      {
-        menu_id: menu_id,
-        menu_name: data[:menu_name],
-        ingredients: data[:ingredients]
+      # 分けたデータをそれぞれ配列に格納し、menu_idごとのハッシュに追加
+      result[menu_id] = {
+        "special_unit_ids" => special_unit_ids,
+        "other_units" => other_units
       }
     end
+
+    categorized_ingredients.each do |menu_id, categories|
+      # menu_idに対応するmenu_nameを取得
+      menu = Menu.find(menu_id)
+      menu_name = menu.menu_name
+      processed_results[menu_name] ||= []
+
+      # "special_unit_ids" の処理
+      special_units_processed = categories["special_unit_ids"].group_by(&:material_name).map do |_, ingredients|
+        ingredients.first
+      end
+
+      # "other_units" の処理: ここでは例として同じ material_name の quantity を合算する簡単な例を示します
+      other_units_processed = cooking_flows_aggregate_ingredients(categories["other_units"])
+
+      # 処理結果を menu_id ごとの配列に統合
+      processed_results[menu_name].concat(special_units_processed + other_units_processed)
+    end
+
+    processed_results
   end
 
+  def duplicate_ingredients(menu_ingredients, menu_item_counts)
+    # menu_idごとに複製されたingredientsを格納するハッシュを初期化
+    grouped_ingredients = {}
+
+    # 各menu_ingredientに対して処理を実行
+    menu_ingredients.each do |menu_ingredient|
+      menu_id = menu_ingredient.menu_id
+      ingredient = menu_ingredient.ingredient
+      # 該当するmenu_idのmenu_item_countsを取得、存在しない場合は0とする
+      count = menu_item_counts[menu_id] || 0
+
+      # menu_idキーがまだ存在しない場合は、空の配列を作成
+      grouped_ingredients[menu_id] ||= []
+
+      # menu_item_countsの数だけingredientを複製し、配列に追加
+      count.times do
+        # ここではシンプルな複製を想定していますが、実際にはdeep copyが必要な場合があります
+        duplicated_ingredient = ingredient.dup
+        # quantityの計算を行い、複製したingredientに設定
+        duplicated_ingredient.quantity = ingredient.quantity ? ingredient.quantity * count : nil
+
+        # 複製したingredientをgrouped_ingredientsに追加
+        grouped_ingredients[menu_id] << duplicated_ingredient
+      end
+    end
+
+    grouped_ingredients
+  end
+
+  def cooking_flows_aggregate_ingredients(ingredient_list)
+    min_duplicate_count = 1
+    aggregated_ingredients = []
+
+    # material_idに基づいてグループ化
+    grouped_ingredients = ingredient_list.group_by(&:material_id)
+
+    grouped_ingredients.each do |material_id, ingredients_group|
+      # 重複していない食材の処理
+      if ingredients_group.length <= min_duplicate_count
+        aggregated_ingredients << ingredients_group.first
+        next
+      end
+
+      material = Material.find_by(id: material_id)
+      material_name = material.material_name
+      # 重複している食材の処理
+      total_quantity, unit_id_to_use = cooking_flows_aggregate_quantities(ingredients_group)
+
+      # 「material_id」、合算した「数量」、「デフォルト単位」を１つのインスタンスとして再構成
+      aggregated_ingredient = Ingredient.new(
+        material_name: material_name,
+        material_id: material_id,
+        quantity: total_quantity,
+        unit_id: unit_id_to_use
+      )
+
+      aggregated_ingredients << aggregated_ingredient
+    end
+
+    aggregated_ingredients
+  end
+
+    # 食材が重複した場合、「MaterialUnit」にある"変換率"をかけて合算し、
+  # 「Material」にある"デフォルトのunit_id"を単位に設定する
+  def cooking_flows_aggregate_quantities(grouped_ingredients)
+
+    # 複数の食材の合算数値
+    total_quantity = 0
+    exception_unit_id = @settings.dig('ingredient', 'no_quantity_unit_id').to_i
+    exception_ingredient_quantity = @settings.dig('ingredient', 'exception_ingredient_quantity')
+
+    # グループ内で使用されている全てのunit_idを取得
+    filtered_unit_ids = grouped_ingredients.map(&:unit_id).uniq
+    unique_unit_id_threshold = @settings.dig('limits', 'unique_unit_id_threshold')
+
+    # グループ内で使用されている全てのunit_idが同じかどうかを確認
+    is_same_unit_id = filtered_unit_ids.length == unique_unit_id_threshold
+
+    # 使用するunit_idを決定
+    unit_id_to_use = if is_same_unit_id
+      grouped_ingredients.first.unit_id
+    else
+      grouped_ingredients.first.material.default_unit_id
+    end
+
+    # 同じunit_idである場合と異なる場合で合算ロジックを分ける
+    if is_same_unit_id
+      # グループ内のunit_idが全て同じでその単位で合算
+      total_quantity = grouped_ingredients.sum(&:quantity)
+    else
+      # 異なるunit_idが存在する場合、materialのdefault_unit_idを使用して合算
+      total_quantity = grouped_ingredients.reduce(0) do |sum, ingredient|
+        material_unit = MaterialUnit.find_by(material_id: ingredient.material_id, unit_id: ingredient.unit_id)
+        conversion_factor = material_unit.conversion_factor
+        quantity = ingredient.quantity || exception_ingredient_quantity
+        sum + quantity * conversion_factor
+      end
+    end
+
+    [total_quantity, unit_id_to_use]
+  end
 
   # 作り方に関するインスタンスデータから各データに関連するRecipeStepの情報とmenu_nameを取得し、
   # それらをハッシュの配列として整理するメソッド

--- a/app/views/cooking_flows/index.html.erb
+++ b/app/views/cooking_flows/index.html.erb
@@ -19,14 +19,16 @@
 
 
   <div class="ingredients-section">
-    <% @ingredients.each do |menu_data| %>
-      <p class="ingredient-overview">　食材リスト（<%= truncate(menu_data[:menu_name], length: 9, omission: '..') %>）　</p>
-      <% menu_data[:ingredients].each do |ingredient_data| %>
+    <% @ingredients.each do |menu_name, ingredients| %>
+      <p class="ingredient-overview">　食材リスト（<%= truncate(menu_name, length: 9, omission: '..') %>）　</p>
+      <% ingredients.each do |ingredient| %>
         <div class="ingredient-item">
-          <p class="material-name"><%= ingredient_data[:ingredient].material_name %></p>
+          <p class="material-name"><%= ingredient.material_name %></p>
           <div class="quantity-unit">
-            <p class="quantity"><%= display_quantity(ingredient_data[:quantity]) %></p>
-            <p class="unit"><%= ingredient_data[:unit_name] %></p>
+            <% if ingredient.quantity.present? %>
+              <p class="quantity"><%= display_quantity(ingredient.quantity) %></p>
+            <% end %>
+            <p class="unit"><%= ingredient.unit.unit_name %></p>
           </div>
         </div>
       <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,8 @@ ingredient:
   no_quantity_unit_id: 17
   exception_ingredient_quantity: 0.5
   default_unit_id: 1
+  min_ingredients_to_merge: 1
+  default_ingredient_quantity: 0
 
 limits:
   max_total_items: 20


### PR DESCRIPTION
目的：
レシピ表示の食材表示をユーザーが直感的に理解しやすい形に統一することが目的です。

内容：
レシピの詳細画面：
→特定の単位での食材表示を1つだけにする設定を追加
→レシピ単体表示時の食材表示をユーザーが混乱しないよう調整

調理時のレシピ確認画面：
→特定の単位での食材表示を1つだけにする設定を追加
→レシピ単体表示時の食材表示をユーザーが混乱しないよう調整
