### PR TITLE
特殊単位選択後の入力不可問題を修正し、マジックナンバーを整理

### DIFF
--- a/app/javascript/add_form.js
+++ b/app/javascript/add_form.js
@@ -221,7 +221,7 @@ function updateForm(){
   }
 }
 
-// 食材セット時にunitフォームへ専用の単位を設定する（addForm.jsでも使用しています。）
+// 食材セット時にunitフォームへ専用の単位を設定する
 function handleIngredientNameChange(selectElement, value, selectedUnitId) {
   const NO_QUANTITY_UNIT_ID = "17";
   const material_name = value;

--- a/app/javascript/ingredient_dropdown.js
+++ b/app/javascript/ingredient_dropdown.js
@@ -233,11 +233,18 @@ function handleIngredientNameChange(selectElement, value) {
 
     data.forEach(item => {
       const option = document.createElement('option');
+      const inputElement = selectElement.closest('div').querySelector(".ingredient-quantity");
       option.value = item.id;
       option.textContent = item.name;
       selectElement.appendChild(option);
       selectElement.style.pointerEvents = 'auto';
       selectElement.removeAttribute('tabindex');
+      inputElement.style.backgroundColor = "";
+      inputElement.style.pointerEvents = "auto";
+      inputElement.removeAttribute("readonly");
+      inputElement.removeAttribute("tabindex");
+      inputElement.value = "";
+      inputElement.placeholder = "数量";
     });
   });
 }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,9 @@ limits:
   max_decimal_places: 1
   max_image_size_in_megabytes: 5
   min_items_to_scale: 1
+  default_menu_item_count: 0
+  min_duplicate_count: 1
+  total_quantity: 0
 
 confirmation:
   token_validity_hours: 24


### PR DESCRIPTION
目的：
レシピ登録時に特殊単位選択後に生じる入力制限の不具合を解消し、コード内のマジックナンバーを明確な設定値へ置き換えることという目的です。

内容：
・特殊単位「少々」選択時のフォーム入力制限問題を修正
・マジックナンバーをsettings.ymlに定義した値へ置き換え
・入力フォームのスタイルと有効性を動的に制御するロジックを改善