### PR TITLE
無駄なセッション管理するコードを削除

### DIFF
--- a/app/controllers/custom_sessions_controller.rb
+++ b/app/controllers/custom_sessions_controller.rb
@@ -26,8 +26,6 @@ class CustomSessionsController < ApplicationController
       set_flash_and_redirect(:error, "メールアドレス認証を行ってください。", root_path)
     end
 
-    #セッションIDを払い出す
-    session[:user_id] = user.id
     # current_userに値を設定する
     sign_in(user)
     #もし一致する場合にはroot_pathへ移動

--- a/app/controllers/custom_sessions_controller.rb
+++ b/app/controllers/custom_sessions_controller.rb
@@ -27,7 +27,7 @@ class CustomSessionsController < ApplicationController
     end
 
     # current_userに値を設定する
-    sign_in(user)
+    sign_in user
     #もし一致する場合にはroot_pathへ移動
     set_flash_and_redirect(:notice, "ログインしました。", root_path)
   end


### PR DESCRIPTION
目的：
Deviseの認証機能を活用して、冗長なセッション管理コードの削除を行い、コードの効率化と保守性の向上を図るという目的です。

内容：
・Devise認証に依存する旨を明確にするため、手動でセッションを管理するコードを削除
