### PR TITLE
リレーション名の誤りを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,6 @@ end
 gem 'devise'
 gem 'pry-rails'
 gem 'pry-byebug'
-gem 'action_args'
 gem 'sassc'
 gem 'image_processing'
 gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_args (2.7.3)
     actioncable (7.0.5.1)
       actionpack (= 7.0.5.1)
       activesupport (= 7.0.5.1)
@@ -314,7 +313,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  action_args
   bootsnap
   capybara
   debug

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,6 +1,6 @@
 class Menu < ApplicationRecord
   has_many :user_menu, dependent: :destroy
-  has_many :users, through: :menu_users
+  has_many :users, through: :user_menu
   has_one_attached :image
   has_many :menu_ingredients, dependent: :destroy
   has_many :ingredients, through: :menu_ingredients, autosave: false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  has_many :menu_users, dependent: :destroy
-  has_many :menus, through: :menu_users
+  has_many :user_menu, dependent: :destroy
+  has_many :menus, through: :user_menu
   has_one :cart, dependent: :destroy
   has_many :shopping_lists, dependent: :destroy
 


### PR DESCRIPTION
目的：
データベースの整合性を確保し、アプリケーションの関連付けエラーを解消するため、Menuモデル内のリレーション名の誤りを修正します。

内容：
・Menuモデルのhas_many :user_menuをhas_many :menu_usersに変更