### PR TITLE
テキストエリアの横幅固定と縦リサイズ範囲を設定

### DIFF
--- a/app/assets/stylesheets/menu/menu_registration.scss
+++ b/app/assets/stylesheets/menu/menu_registration.scss
@@ -160,6 +160,9 @@
               border-bottom: 1px solid #ccc;
               padding:5px;
               font-size: 16px;
+              resize: vertical;
+              min-height: 45px;
+              max-height: 180px;
             }
 
             .select-dropdown{


### PR DESCRIPTION
目的：
テキストエリアの操作範囲を明確にしユーザの入力体験を向上させるためのスタイル更新が目的です。

内容：
・テキストエリアの横幅を300pxに固定
・縦方向のサイズ変更を可能にするためのresizeプロパティを設定
・テキストエリアの最小高さを100px、最大高さを300pxに設定

<img width="772" alt="スクリーンショット 2024-03-04 20 10 42" src="https://github.com/shinke1171718/Autonomy_app/assets/110751171/c783c238-3c72-4f83-bb4f-6e56e2b1ade8">
